### PR TITLE
feat: 사용자 회원가입 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,42 +2,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.8</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/> 
 	</parent>
+	
 	<groupId>com.ssook.mvc</groupId>
 	<artifactId>SSOOK_BACK</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>SSOOK_BACK</name>
 	<description>Study shorts</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+	
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+	
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.3</version>
 		</dependency>
 
 		<dependency>
@@ -46,16 +38,19 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -64,7 +59,7 @@
 		<dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter-test</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.3</version>
 			<scope>test</scope>
 		</dependency>
 		
@@ -80,25 +75,14 @@
 		</dependency>
 		
 		<dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-starter-security</artifactId>
+		    <groupId>org.mindrot</groupId>
+		    <artifactId>jbcrypt</artifactId>
+		    <version>0.4</version>
 		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/ssook/mvc/common/ApiResponse.java
+++ b/src/main/java/com/ssook/mvc/common/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.ssook.mvc.common;
+
+import java.util.Collections;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private int status;       // 201, 200, 400 등등
+    private String message;   // "회원 가입이 완료되었습니다."
+    private T data;
+
+    // [데이터 포함] 조회 성공 시 사용 (예: 내 정보 조회, 영상 목록)
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(200, "요청이 성공했습니다.", data);
+    }
+
+    // [메시지 중심] 생성/수정/삭제 성공 시 사용 (예: 회원가입, 로그아웃)
+    public static <T> ApiResponse<T> createSuccess(String message) {
+        // 데이터 자리에 빈 리스트(Collections.emptyList())를 넣어서 []로 보냄
+        return new ApiResponse<>(201, message, (T) Collections.emptyList());
+    }
+}

--- a/src/main/java/com/ssook/mvc/config/SecurityConfig.java
+++ b/src/main/java/com/ssook/mvc/config/SecurityConfig.java
@@ -1,30 +1,7 @@
 package com.ssook.mvc.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
-@EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(); // 실무에서 가장 많이 쓰는 해시 암호화
-    }
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable()) // API 서버 개발 시 CSRF 설정 비활성화 (필수)
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // API와 문서는 누구나 접근 가능
-                .anyRequest().authenticated() // 그 외는 인증 필요
-            );
-        return http.build();
-    }
 }

--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -1,37 +1,31 @@
 package com.ssook.mvc.controller;
 
-import com.ssook.mvc.entity.UserEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.service.UserService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/users")
-@Tag(name = "User API", description = "회원 관리 API")
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-    public UserController(UserService userService) {
-        this.userService = userService;
-    }
-
+    // 회원가입 API
     @PostMapping("/signup")
-    @Operation(summary = "회원가입", description = "중복 검사 및 암호화를 포함한 회원가입")
-    // @Valid: DTO에 붙인 @NotBlank 같은 조건을 검사함
-    public ResponseEntity<String> signup(@Valid @RequestBody UserEntity userEntity) {
-        try {
-            userService.signup(userEntity);
-            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공!");
-        } catch (IllegalArgumentException e) {
-            // 중복된 이메일/닉네임일 경우 400 에러와 메시지 반환
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러가 발생했습니다.");
-        }
+    public ApiResponse<Object> signup(@Valid @RequestBody UserJoinRequest request) {
+        // 1. 서비스에 회원가입 요청
+        userService.signup(request);
+        
+        // 2. 성공 메시지 반환 (나중에 ApiResponse로 변경 가능)
+        return ApiResponse.createSuccess("회원 가입이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserJoinRequest.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserJoinRequest.java
@@ -1,0 +1,40 @@
+package com.ssook.mvc.dto.user;
+
+import com.ssook.mvc.entity.UserEntity;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserJoinRequest {
+    
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 4, message = "비밀번호는 최소 4자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    private String intro; 
+
+    // DTO -> Entity 변환
+    public UserEntity toEntity(String encodedPassword) {
+        return UserEntity.builder()
+                .email(this.email)
+                .password(encodedPassword)
+                .nickname(this.nickname)
+                .role("ROLE_USER")
+                .intro(this.intro)
+                // createdAt은 DB가 자동으로 넣거나, MyBatis 쿼리에서 처리
+                .build();
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/user/temp.java
+++ b/src/main/java/com/ssook/mvc/dto/user/temp.java
@@ -1,4 +1,0 @@
-package com.ssook.mvc.dto.user;
-
-public class temp {
-}

--- a/src/main/java/com/ssook/mvc/entity/BaseEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/BaseEntity.java
@@ -1,7 +1,11 @@
 package com.ssook.mvc.entity;
 
+import lombok.Getter;
+import lombok.Setter;
 import java.time.LocalDateTime;
 
+@Getter
+@Setter
 public abstract class BaseEntity {
     private LocalDateTime createdAt; // 생성일시
     private LocalDateTime updatedAt; // 수정일시

--- a/src/main/java/com/ssook/mvc/entity/UserEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/UserEntity.java
@@ -1,39 +1,22 @@
 package com.ssook.mvc.entity;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import lombok.Data;
-import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
-@Schema(description = "회원 가입 요청 데이터")
-public class UserEntity {
-
-    @Schema(hidden = true)
-    private Long userId;
-
-    @NotBlank(message = "이메일은 필수입니다.")
-    @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @Schema(description = "로그인 이메일", example = "ssafy@ssook.com")
-    private String email;
-
-    @NotBlank
-    @Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.")
-    @Schema(description = "비밀번호", example = "1234")
-    private String password;
-
-    @NotBlank(message = "닉네임은 필수입니다.")
-    @Schema(description = "닉네임", example = "쑥쑥이")
-    private String nickname;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserEntity extends BaseEntity { // 상속
     
-    // ... 나머지 필드 동일
-    @Schema(hidden = true)
-    private String role;
-    private String intro;
-    @Schema(hidden = true)
-    private LocalDateTime createdAt;
-    @Schema(hidden = true)
-    private LocalDateTime updatedAt;
+    private Long userId;        // DB: user_id (PK)
+    private String email;       // DB: email
+    private String password;    // DB: password
+    private String nickname;    // DB: nickname
+    private String role;        // DB: role
+    private String intro;       // DB: intro
+    
+    // createdAt, updatedAt은 부모(BaseEntity)에 있으므로 생략
 }

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -5,8 +5,13 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface UserMapper {
-    // 회원가입 (DB에 저장 성공하면 1, 실패하면 0 반환)
-    int insertUser(UserEntity userEntity);
-    int existsByEmail(String email);
-    int existsByNickname(String nickname);
+    // 1. 회원 정보 저장 (Insert)
+    void saveUser(UserEntity user);
+
+    // 2. 이메일 중복 체크 (Count가 1 이상이면 true)
+    boolean existsByEmail(String email);
+
+    // 3. 닉네임 중복 체크
+    boolean existsByNickname(String nickname);
 }
+

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -1,39 +1,42 @@
 package com.ssook.mvc.service;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.mindrot.jbcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.entity.UserEntity;
 import com.ssook.mvc.repository.UserMapper;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserMapper userMapper;
-    private final PasswordEncoder passwordEncoder; // 암호화 기계 주입
-
-    public UserService(UserMapper userMapper, PasswordEncoder passwordEncoder) {
-        this.userMapper = userMapper;
-        this.passwordEncoder = passwordEncoder;
-    }
 
     @Transactional
-    public void signup(UserEntity userEntity) {
-        // 1. 중복 검사 (실무 필수!)
-        if (userMapper.existsByEmail(userEntity.getEmail()) > 0) {
+    public void signup(UserJoinRequest request) {
+        // 1. 이메일 중복 체크
+        if (userMapper.existsByEmail(request.getEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
-        if (userMapper.existsByNickname(userEntity.getNickname()) > 0) {
+
+        // 2. 닉네임 중복 체크
+        if (userMapper.existsByNickname(request.getNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        // 2. 비밀번호 암호화 (절대 평문 저장 금지!)
-        // "1234" -> "$2a$10$rXn..." 처럼 알아볼 수 없는 문자로 바뀜
-        String encodedPassword = passwordEncoder.encode(userEntity.getPassword());
-        userEntity.setPassword(encodedPassword);
+        // 3. 비밀번호 암호화 (JBCrypt 사용)
+        // hashpw: 비밀번호를 암호화해주는 함수
+        // gensalt: 암호화할 때 쓰는 '소금(Salt)'을 뿌려서 더 안전하게 만듦
+        String encodedPassword = BCrypt.hashpw(request.getPassword(), BCrypt.gensalt());
 
-        // 3. DB 저장
-        userMapper.insertUser(userEntity);
+        // 4. DTO -> Entity 변환 (암호화된 비번 넣기)
+        UserEntity user = request.toEntity(encodedPassword);
+
+        // 5. DB 저장
+        userMapper.saveUser(user);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=SSOOK_BACK
 
 # ===============================
-# 1. 서버 포트 설정
+# 1. 서버 포트 설정
 # ===============================
 server.port=8080
 
 # ===============================
-# 2. MySQL DB 연결 설정 (수정됨)
+# 2. MySQL DB 연결 설정
 # ===============================
 # DB Schema: ssookssook
 # User/PW: ssafy / ssafy
@@ -16,17 +16,14 @@ spring.datasource.username=ssafy
 spring.datasource.password=ssafy
 
 # ===============================
-# 3. MyBatis 설정 (패키지명 반영)
+# 3. MyBatis 설정
 # ===============================
-# Entity 위치: com.ssook.mvc.entity
 mybatis.type-aliases-package=com.ssook.mvc.entity
-# XML Mapper 위치
 mybatis.mapper-locations=classpath:mapper/**/*.xml
-# user_id (DB) -> userId (Java) 자동 변환
+# user_id (DB) -> userId (Java)
 mybatis.configuration.map-underscore-to-camel-case=true
 
 # ===============================
-# 4. 로그 설정 (패키지명 반영)
+# 4. 로그 설정
 # ===============================
-# 우리가 만든 Mapper가 실행될 때 SQL을 콘솔에 출력
 logging.level.com.ssook.mvc.repository=TRACE

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -1,29 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
-"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.ssook.mvc.repository.UserMapper">
 
-    <insert id="insertUser" parameterType="com.ssook.mvc.entity.UserEntity">
+    <insert id="saveUser" parameterType="com.ssook.mvc.entity.UserEntity">
         INSERT INTO users (
             email, 
             password, 
             nickname, 
             role, 
-            intro
+            intro,
+            created_at,
+            updated_at
         ) VALUES (
             #{email}, 
             #{password}, 
             #{nickname}, 
-            'ROLE_USER', #{intro}  )
+            #{role}, 
+            #{intro},
+            NOW(),
+            NOW()
+        )
     </insert>
-    
-    <select id="existsByEmail" resultType="int">
-        SELECT COUNT(*) FROM users WHERE email = #{email}
+
+    <select id="existsByEmail" parameterType="string" resultType="boolean">
+        SELECT EXISTS (SELECT 1 FROM users WHERE email = #{email})
     </select>
-    
-    <select id="existsByNickname" resultType="int">
-        SELECT COUNT(*) FROM users WHERE nickname = #{nickname}
+
+    <select id="existsByNickname" parameterType="string" resultType="boolean">
+        SELECT EXISTS (SELECT 1 FROM users WHERE nickname = #{nickname})
     </select>
 
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 사용자가 이메일, 비밀번호, 닉네임 등을 입력하여 회원가입을 할 수 있는 기능을 구현했습니다.
- 보안을 위해 비밀번호는 단방향 암호화하여 저장하며, 중복된 계정 생성을 방지합니다.
- 관련 이슈: #4 

## 👩‍💻 작업 내용
1. **회원가입 API 구현** (`POST /users/signup`)
   - DTO(`UserJoinRequest`)를 통해 입력값 유효성 검사(`@Valid`) 적용
   - `jbcrypt` 라이브러리를 사용하여 비밀번호 암호화 후 DB 저장
   - `ApiResponse` 공통 객체를 적용하여 응답 포맷 통일

2. **중복 검사 로직 추가**
   - 이메일 및 닉네임 중복 시 예외 처리 (`IllegalArgumentException`)

3. **DB 연동**
   - MyBatis Mapper 및 XML 쿼리 작성 (`users` 테이블)
   - `UserEntity` 생성 및 BaseEntity 상속 구조 적용

## 🛠️ 기술적 의사결정
- **Spring Security 미사용:** 프로젝트 규모와 학습 목적을 고려하여, 무거운 Security 프레임워크 대신 `jbcrypt`와 `Interceptor`를 활용한 경량화된 인증 방식을 채택했습니다.
- **DTO/Entity 분리:** 데이터 전송 객체와 DB 엔티티를 분리하여 유연성과 보안을 강화했습니다.

## ✅ 테스트 결과
- Postman을 통한 회원가입 성공 응답 확인 (Status: 201)
- DB(`users`)에 비밀번호가 암호화되어 저장되는지 확인 완료
- 중복 이메일 가입 시도 시 에러 응답 확인 완료