### PR TITLE
feat : 사용자 로그인 및 JWT 토큰 발급 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,24 @@
 		    <artifactId>jbcrypt</artifactId>
 		    <version>0.4</version>
 		</dependency>
+		
+		<dependency>
+		    <groupId>io.jsonwebtoken</groupId>
+		    <artifactId>jjwt-api</artifactId>
+		    <version>0.11.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>io.jsonwebtoken</groupId>
+		    <artifactId>jjwt-impl</artifactId>
+		    <version>0.11.5</version>
+		    <scope>runtime</scope>
+		</dependency>
+		<dependency>
+		    <groupId>io.jsonwebtoken</groupId>
+		    <artifactId>jjwt-jackson</artifactId>
+		    <version>0.11.5</version>
+		    <scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/ssook/mvc/config/SecurityConfig.java
+++ b/src/main/java/com/ssook/mvc/config/SecurityConfig.java
@@ -1,7 +1,0 @@
-package com.ssook.mvc.config;
-
-
-public class SecurityConfig {
-
-
-}

--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ssook.mvc.common.ApiResponse;
 import com.ssook.mvc.dto.user.UserJoinRequest;
+import com.ssook.mvc.dto.user.UserLoginRequest;
 import com.ssook.mvc.service.UserService;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -27,5 +29,18 @@ public class UserController {
         
         // 2. 성공 메시지 반환 (나중에 ApiResponse로 변경 가능)
         return ApiResponse.createSuccess("회원 가입이 완료되었습니다.");
+    }
+    
+    // 로그인 API
+    @PostMapping("/login")
+    public ApiResponse<Object> login(@RequestBody UserLoginRequest request, HttpServletResponse response) {
+        // 1. 서비스에서 토큰 받아오기
+        String token = userService.login(request);
+
+        // 2. API 명세서대로 헤더에 'token' 추가
+        response.setHeader("token", token);
+
+        // 3. 바디에는 성공 메시지만 반환 (data: [])
+        return ApiResponse.createSuccess("로그인에 성공했습니다.");
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserJoinRequest.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserJoinRequest.java
@@ -26,7 +26,6 @@ public class UserJoinRequest {
 
     private String intro; 
 
-    // DTO -> Entity 변환
     public UserEntity toEntity(String encodedPassword) {
         return UserEntity.builder()
                 .email(this.email)
@@ -34,7 +33,6 @@ public class UserJoinRequest {
                 .nickname(this.nickname)
                 .role("ROLE_USER")
                 .intro(this.intro)
-                // createdAt은 DB가 자동으로 넣거나, MyBatis 쿼리에서 처리
                 .build();
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserLoginRequest.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserLoginRequest.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserLoginRequest {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -1,7 +1,8 @@
 package com.ssook.mvc.repository;
 
-import com.ssook.mvc.entity.UserEntity;
 import org.apache.ibatis.annotations.Mapper;
+
+import com.ssook.mvc.entity.UserEntity;
 
 @Mapper
 public interface UserMapper {
@@ -13,5 +14,6 @@ public interface UserMapper {
 
     // 3. 닉네임 중복 체크
     boolean existsByNickname(String nickname);
+    
+    UserEntity findByEmail(String email);
 }
-

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -5,15 +5,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ssook.mvc.dto.user.UserJoinRequest;
+import com.ssook.mvc.dto.user.UserLoginRequest;
 import com.ssook.mvc.entity.UserEntity;
 import com.ssook.mvc.repository.UserMapper;
+import com.ssook.mvc.util.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
+	
+	private final JwtUtil jwtUtil; // JwtUtil 주입 (RequiredArgsConstructor 덕분에 자동 주입됨)
+	
     private final UserMapper userMapper;
 
     @Transactional
@@ -38,5 +42,19 @@ public class UserService {
 
         // 5. DB 저장
         userMapper.saveUser(user);
+    }
+    
+    @Transactional(readOnly = true) // 읽기 전용 모드 (성능 최적화)
+    public String login(UserLoginRequest request) {
+        // 1. 이메일로 사용자 조회
+        UserEntity user = userMapper.findByEmail(request.getEmail());
+        
+        // 2. 사용자가 없거나, 비밀번호가 틀리면 에러
+        if (user == null || !BCrypt.checkpw(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 3. 인증 성공 시 토큰 생성 후 반환
+        return jwtUtil.generateToken(user.getUserId(), user.getEmail());
     }
 }

--- a/src/main/java/com/ssook/mvc/util/JwtUtil.java
+++ b/src/main/java/com/ssook/mvc/util/JwtUtil.java
@@ -1,0 +1,33 @@
+package com.ssook.mvc.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final long expiration = 1000*60*60; // 1시간
+
+    // 생성자: application.properties에서 jwt.secret 값을 가져와서 세팅
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // 토큰 생성 메서드
+    public String generateToken(Long userId, String email) {
+        return Jwts.builder()
+                .setSubject(email)                  // 토큰 제목 (보통 이메일이나 ID)
+                .claim("userId", userId)            // 추가 정보 (PK)
+                .setIssuedAt(new Date())            // 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + expiration)) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘
+                .compact();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,9 @@ mybatis.configuration.map-underscore-to-camel-case=true
 # 4. 로그 설정
 # ===============================
 logging.level.com.ssook.mvc.repository=TRACE
+
+# ===============================
+# 5. JWT 설정
+# ===============================
+# HS256 알고리즘을 사용하므로 32글자 이상이어야 안전합니다.
+jwt.secret=SsookProjectSecretKeyForJwtLoginTokenGenerate2025

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -31,5 +31,9 @@
     <select id="existsByNickname" parameterType="string" resultType="boolean">
         SELECT EXISTS (SELECT 1 FROM users WHERE nickname = #{nickname})
     </select>
+    
+    <select id="findByEmail" parameterType="string" resultType="com.ssook.mvc.entity.UserEntity">
+    SELECT * FROM users WHERE email = #{email}
+	</select>
 
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 사용자가 이메일과 비밀번호로 로그인하면, 인증 후 JWT(Access Token)를 발급하는 기능을 구현했습니다.
- 관련 이슈: #6

## 👩‍💻 작업 내용
1. **로그인 API 구현** (`POST /users/login`)
   - `UserLoginRequest` DTO를 통해 이메일/비밀번호 수신
   - `UserService`에서 DB 조회 및 비밀번호 일치 여부 확인 (`BCrypt.checkpw`)
   - 로그인 성공 시 Header(`token`)에 JWT 담아서 응답

2. **JWT 유틸리티 구현** (`JwtUtil`)
   - `jjwt` 라이브러리 사용
   - HMAC SHA256 알고리즘으로 서명(Signature) 생성
   - 토큰 만료 시간: 1시간 설정

3. **응답 포맷 통일**
   - Body: `{ status: 201, message: "로그인 성공", data: [] }`
   - Header: `token: eyJhbG...` (API 명세 준수)

## 🛠️ 기술적 의사결정
- **Token 위치:** 보안 및 클라이언트 처리를 고려하여 Access Token을 Response Body가 아닌 **Header**에 포함시켰습니다.
- **예외 처리:** 비밀번호 불일치 시 명확한 예외 메시지(`IllegalArgumentException`)를 반환하도록 처리했습니다.

## ✅ 테스트 결과
- Postman 테스트 완료: 로그인 성공 시 헤더에 토큰 발급 확인
- 비밀번호 틀렸을 경우 500 에러 및 메시지 확인 완료