### PR TITLE
Feat: Video - 영상 목록 조회 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -1,0 +1,38 @@
+package com.ssook.mvc.controller;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import com.ssook.mvc.service.VideoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/video")
+public class VideoController {
+    private final VideoService videoService;
+
+    @Autowired
+    public VideoController(VideoService videoService) {
+        this.videoService = videoService;
+    }
+
+    // 영상 목록 조회
+    @GetMapping
+    public ApiResponse<Map<String, Object>> getVideoList(@ModelAttribute VideoListRequestDto videoListRequestDto) {
+        // 서비스 호출로 영상 목록 가져와서 videos에 할당
+        List<VideoListResponseDto> videos = videoService.getVideoList(videoListRequestDto);
+        // Map에 videos넣기
+        Map<String, Object> data = new HashMap<>();
+        data.put("videos", videos);
+
+        return ApiResponse.success(data);
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
@@ -1,0 +1,16 @@
+package com.ssook.mvc.dto.video.request;
+
+import lombok.Data;
+
+@Data
+public class VideoListRequestDto {
+    private String categoryName; // 카테고리 명
+    private Integer sortedType; // 정렬기준(1: 최신순, 2: 조회수순)
+    private int page = 1; // 페이지 번호
+    private int size = 12; // 페이지당 개수
+
+    // SQL LIMIT에서 사용할 offset
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/video/response/VideoListResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/response/VideoListResponseDto.java
@@ -1,0 +1,10 @@
+package com.ssook.mvc.dto.video.response;
+
+import lombok.Data;
+
+@Data
+public class VideoListResponseDto {
+    private Long videoId;
+    private String thumbnailUrl;
+    private Integer viewCount;
+}

--- a/src/main/java/com/ssook/mvc/dto/video/temp.java
+++ b/src/main/java/com/ssook/mvc/dto/video/temp.java
@@ -1,4 +1,0 @@
-package com.ssook.mvc.dto.video;
-
-public class temp {
-}

--- a/src/main/java/com/ssook/mvc/entity/VideoEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/VideoEntity.java
@@ -17,6 +17,6 @@ public class VideoEntity extends BaseEntity{
     private String title;
     private String videoUrl;
     private String thumbnailUrl;
-    private Integer viewCnt;
+    private Integer viewCount;
 
 }

--- a/src/main/java/com/ssook/mvc/repository/VideoMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/VideoMapper.java
@@ -1,0 +1,12 @@
+package com.ssook.mvc.repository;
+
+import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface VideoMapper {
+    List<VideoListResponseDto> selectVideoList(VideoListRequestDto videoListRequestDto);
+}

--- a/src/main/java/com/ssook/mvc/service/VideoService.java
+++ b/src/main/java/com/ssook/mvc/service/VideoService.java
@@ -1,0 +1,29 @@
+package com.ssook.mvc.service;
+
+import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import com.ssook.mvc.repository.VideoMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class VideoService {
+    private final VideoMapper videoMapper;
+
+    @Autowired
+    public VideoService(VideoMapper videoMapper) {
+        this.videoMapper = videoMapper;
+    }
+
+    // 영상 목록 조회
+    @Transactional
+    public List<VideoListResponseDto> getVideoList(VideoListRequestDto videoListRequestDto) {
+        if(videoListRequestDto.getSortedType() == null)
+            videoListRequestDto.setSortedType(1);
+
+        return videoMapper.selectVideoList(videoListRequestDto);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.datasource.password=ssafy
 # ===============================
 # 3. MyBatis 설정
 # ===============================
-mybatis.type-aliases-package=com.ssook.mvc.entity
+mybatis.type-aliases-package=com.ssook.mvc
 mybatis.mapper-locations=classpath:mapper/**/*.xml
 # user_id (DB) -> userId (Java)
 mybatis.configuration.map-underscore-to-camel-case=true

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssook.mvc.repository.VideoMapper">
+    <!-- 영상 목록 조회 -->
+    <select id="selectVideoList" parameterType="VideoListRequestDto" resultType="VideoListResponseDto">
+        SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount
+        FROM video v
+        LEFT JOIN category c ON v.category_id = c.category_id
+        WHERE 1=1
+
+        <if test="categoryName != null and categoryName != ''">
+            AND c.category_name = #{categoryName}
+        </if>
+
+        ORDER BY
+        <choose>
+            <when test="sortedType == 2">
+                v.view_count DESC, v.created_at DESC
+            </when>
+            <otherwise>
+                v.created_at DESC
+            </otherwise>
+        </choose>
+
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+</mapper>


### PR DESCRIPTION
## 📌 개요
- 영상 목록 조회 구현

## 👩‍💻 작업 내용
1. 쇼츠 목록 조회 API 구현 (GET /video)
    - 카테고리별 필터링 및 정렬(최신순, 조회수순) 기능 구현
    - MyBatis 동적 쿼리(`<if>, <choose>`)를 활용하여 다양한 검색 조건 처리
2. 페이지네이션(Pagination) 로직 추가
    - 무한 스크롤 UI를 지원하기 위해 백엔드에서 LIMIT, OFFSET을 활용한 페이징 처리 구현 (VideoListRequestDto 내 offset 계산 로직 포함)
    - 대량의 데이터 조회 시 성능 저하 방지

## 🛠️ 기술적 의사결정
- Offset 기반 페이지네이션 적용
    - 프론트엔드 UI는 무한 스크롤 형태이지만, 전체 데이터를 한 번에 조회할 경우 DB 부하와 응답 속도 저하가 우려되었습니다. 이에 따라 백엔드에서는 page와 size 파라미터를 받아 필요한 데이터만 분할 조회하는 Offset Paging 방식을 채택하여 성능과 리소스 효율을 최적화했습니다.

- DTO 분리 (Request/Response)
    - VideoEntity를 직접 반환하지 않고 VideoListResponseDto를 별도로 생성했습니다. 이를 통해 API 명세서(videoId, thumbnailUrl, viewCount)를 정확히 준수하고, 불필요한 엔티티 정보 노출을 막아 유지보수성을 높였습니다.

## ✅ 테스트 결과
- http://localhost:8080/video?page=1&size=5
    - 1페이지 5개(최신순)
- http://localhost:8080/video?categoryName=개발&page=1&size=10
    -  1페이지 10개 개발 카테고리만(최신순)
- http://localhost:8080/video?sortedType=2&page=1
    - 1페이지 12개(디폴트값 - 조회수순)

## 🔗 관련 이슈
- #9 