### PR TITLE
feat : JWT 인터셉터 및 WebConfig 보안 설정 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/config/WebConfig.java
+++ b/src/main/java/com/ssook/mvc/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.ssook.mvc.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.ssook.mvc.interceptor.JwtInterceptor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtInterceptor jwtInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/**") // 1. 기본적으로 모든 URL을 막음
+                .excludePathPatterns(   // 2. 아래 URL들은 검사 제외 (화이트리스트)
+                        "/users/signup",  // 회원가입
+                        "/users/login",   // 로그인
+                        "/swagger-ui/**", // 스웨거 (문서)
+                        "/v3/api-docs/**" // 스웨거 (문서)
+                );
+    }
+}

--- a/src/main/java/com/ssook/mvc/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/ssook/mvc/interceptor/JwtInterceptor.java
@@ -1,0 +1,41 @@
+package com.ssook.mvc.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.ssook.mvc.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 1. 요청의 Method가 'OPTIONS'인 경우 통과 (CORS 예비 요청 처리)
+        // Vue.js가 "나 요청 보내도 돼?" 하고 찔러보는 건데 막으면 안 됨
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+
+        // 2. 헤더에서 'token' 꺼내기
+        String token = request.getHeader("token");
+
+        // 3. 토큰이 있고 && 유효한지 검사
+        if (token != null && jwtUtil.validateToken(token)) {
+            // [꿀팁 적용] 토큰이 유효하면 userId를 꺼내서 요청 객체(request)에 담아둠
+            // 이제 Controller에서는 request.getAttribute("userId")로 바로 꺼내 쓸 수 있음!
+            Long userId = jwtUtil.getUserId(token);
+            request.setAttribute("userId", userId);
+            
+            return true; // 통과! (Controller로 이동)
+        }
+
+        // 4. 토큰이 없거나 가짜면 에러 응답 (401 Unauthorized)
+        throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+    }
+}

--- a/src/main/java/com/ssook/mvc/util/JwtUtil.java
+++ b/src/main/java/com/ssook/mvc/util/JwtUtil.java
@@ -13,7 +13,7 @@ import java.util.Date;
 public class JwtUtil {
 
     private final Key key;
-    private final long expiration = 1000*60*60; // 1시간
+    private final long expiration = 1000*60*60*24*14; // 1시간 할건데 일단 테스트때는 2주!
 
     // 생성자: application.properties에서 jwt.secret 값을 가져와서 세팅
     public JwtUtil(@Value("${jwt.secret}") String secretKey) {
@@ -29,5 +29,28 @@ public class JwtUtil {
                 .setExpiration(new Date(System.currentTimeMillis() + expiration)) // 만료 시간
                 .signWith(key, SignatureAlgorithm.HS256) // 암호화 알고리즘
                 .compact();
+    }
+    
+    // 토큰 유효성 검사 (위조? 만료? 등등 체크)
+    public boolean validateToken(String token) {
+        try {
+            // 토큰을 파싱해서 서명이 맞는지, 만료되지 않았는지 확인
+            // 문제가 있으면 알아서 에러(Exception)를 던집니다.
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            // 서명이 틀렸거나, 만료되었거나, 형식이 이상하면 false 반환
+            return false;
+        }
+    }
+
+    // 토큰에서 UserId 꺼내기 (꿀팁용)
+    public Long getUserId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId", Long.class); // generateToken에서 넣었던 키값("userId")
     }
 }


### PR DESCRIPTION
## 📌 개요
- 로그인된 사용자만 접근할 수 있도록 API 요청을 가로채 검증하는 `JwtInterceptor`를 구현했습니다.
- 관련 이슈: #6

## 👩‍💻 작업 내용
1. **JwtInterceptor 구현**
   - 요청 헤더(`token`)를 검사하여 유효하지 않거나 없으면 `401 Unauthorized` (또는 500 예외) 처리
   - 검증 성공 시, `request` 속성에 `userId`를 저장하여 컨트롤러 편의성 제공

2. **WebConfig 설정**
   - `HandlerInterceptor` 등록
   - 인증 제외 경로 설정: `/users/signup`, `/users/login`, `/swagger-ui/**` 등

3. **JwtUtil 기능 확장**
   - `validateToken()`: 토큰 유효성 검증 로직 추가
   - `getUserId()`: 토큰에서 사용자 ID 추출 로직 추가
   - 개발 편의를 위해 만료 시간을 임시로 2주로 연장

## 🛠️ 기술적 의사결정
- **Interceptor vs Filter:** Spring Context(Service, Bean)에 접근하기 용이하고, 특정 URL 패턴에만 적용하기 유연한 **Interceptor** 방식을 채택했습니다.

## ✅ 테스트 결과
- Postman 테스트: 헤더에 토큰 없이 요청 시 에러 발생 확인
- 유효한 토큰 포함 시 404(Controller 도달) 확인 완료