### PR TITLE
feat : 사용자 내 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -1,15 +1,18 @@
 package com.ssook.mvc.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.user.UserInfoResponse;
 import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.dto.user.UserLoginRequest;
 import com.ssook.mvc.service.UserService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,23 +27,36 @@ public class UserController {
     // 회원가입 API
     @PostMapping("/signup")
     public ApiResponse<Object> signup(@Valid @RequestBody UserJoinRequest request) {
-        // 1. 서비스에 회원가입 요청
+        // 서비스에 회원가입 요청
         userService.signup(request);
         
-        // 2. 성공 메시지 반환 (나중에 ApiResponse로 변경 가능)
+        // 성공 메시지 반환 (나중에 ApiResponse로 변경 가능)
         return ApiResponse.createSuccess("회원 가입이 완료되었습니다.");
     }
     
     // 로그인 API
     @PostMapping("/login")
     public ApiResponse<Object> login(@RequestBody UserLoginRequest request, HttpServletResponse response) {
-        // 1. 서비스에서 토큰 받아오기
+        // 서비스에서 토큰 받아오기
         String token = userService.login(request);
 
-        // 2. API 명세서대로 헤더에 'token' 추가
+        // API 명세서대로 헤더에 'token' 추가
         response.setHeader("token", token);
 
-        // 3. 바디에는 성공 메시지만 반환 (data: [])
+        // 바디에는 성공 메시지만 반환 (data: [])
         return ApiResponse.createSuccess("로그인에 성공했습니다.");
+    }
+    
+ // 내 정보 조회 API
+    @GetMapping("/me")
+    public ApiResponse<UserInfoResponse> getMyInfo(HttpServletRequest request) {
+        // Interceptor가 넣어둔 "userId"
+        Long userId = (Long) request.getAttribute("userId");
+        
+        // 서비스 호출
+        UserInfoResponse userInfo = userService.getMyInfo(userId);
+        
+        // 응답 (데이터가 담긴 성공 응답)
+        return ApiResponse.success(userInfo);
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserInfoResponse.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserInfoResponse.java
@@ -1,0 +1,27 @@
+package com.ssook.mvc.dto.user;
+
+import com.ssook.mvc.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoResponse {
+    
+    private String email;
+    private String nickname;
+    private String intro;
+    private String role;
+
+    // Entity -> DTO 변환 메서드 (편의상 여기에 만듦)
+    public static UserInfoResponse from(UserEntity user) {
+        return UserInfoResponse.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .intro(user.getIntro())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -6,14 +6,16 @@ import com.ssook.mvc.entity.UserEntity;
 
 @Mapper
 public interface UserMapper {
-    // 1. 회원 정보 저장 (Insert)
+    // 회원 정보 저장 (Insert)
     void saveUser(UserEntity user);
 
-    // 2. 이메일 중복 체크 (Count가 1 이상이면 true)
+    // 이메일 중복 체크 (Count가 1 이상이면 true)
     boolean existsByEmail(String email);
 
-    // 3. 닉네임 중복 체크
+    // 닉네임 중복 체크
     boolean existsByNickname(String nickname);
     
     UserEntity findByEmail(String email);
+    
+    UserEntity findById(Long userId);
 }

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -4,6 +4,7 @@ import org.mindrot.jbcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ssook.mvc.dto.user.UserInfoResponse;
 import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.dto.user.UserLoginRequest;
 import com.ssook.mvc.entity.UserEntity;
@@ -57,4 +58,20 @@ public class UserService {
         // 3. 인증 성공 시 토큰 생성 후 반환
         return jwtUtil.generateToken(user.getUserId(), user.getEmail());
     }
+    
+    // 내 정보 조회
+    @Transactional(readOnly = true)
+    public UserInfoResponse getMyInfo(Long userId) {
+        // DB에서 조회
+        UserEntity user = userMapper.findById(userId);
+        
+        // 없으면 에러 (혹시 탈퇴했거나 잘못된 토큰일 경우)
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+        
+        // Entity -> DTO 변환해서 반환 (비밀번호 제외됨)
+        return UserInfoResponse.from(user);
+    }
+    
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -35,5 +35,9 @@
     <select id="findByEmail" parameterType="string" resultType="com.ssook.mvc.entity.UserEntity">
     SELECT * FROM users WHERE email = #{email}
 	</select>
+	
+	<select id="findById" parameterType="long" resultType="com.ssook.mvc.entity.UserEntity">
+    SELECT * FROM users WHERE user_id = #{userId}
+	</select>
 
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 로그인한 사용자가 자신의 프로필 정보(이메일, 닉네임 등)를 조회하는 API를 구현했습니다.
- 관련 이슈: #14

## 👩‍💻 작업 내용
1. **내 정보 조회 API 구현** (`GET /users/me`)
   - `JwtInterceptor`에서 주입한 `userId` 속성(`request.getAttribute`)을 활용하여 요청 사용자 식별
   - `UserService`에서 PK(`user_id`)로 사용자 정보 조회
   - 비밀번호 등 민감 정보를 제외한 `UserInfoResponse` DTO 변환 후 반환

2. **MyBatis 매퍼 추가**
   - `findById`: PK 기반 단건 조회 쿼리 추가

## 🛠️ 기술적 의사결정
- **DTO 분리:** `UserEntity`를 직접 반환할 경우 비밀번호가 노출될 위험이 있어, 보여줄 필드만 담은 `UserInfoResponse`를 별도로 정의하여 보안성을 높였습니다.
- **Request Attribute 활용:** 컨트롤러에서 매번 토큰을 파싱하지 않고, 인터셉터가 미리 파싱해둔 `userId`를 재사용하여 성능과 코드 가독성을 개선했습니다.

## ✅ 테스트 결과
- Postman 테스트 완료: 유효한 토큰으로 요청 시 200 OK 및 내 정보 JSON 응답 확인