### PR TITLE
Feat: Video - 영상 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -2,13 +2,12 @@ package com.ssook.mvc.controller;
 
 import com.ssook.mvc.common.ApiResponse;
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
 import com.ssook.mvc.dto.video.response.VideoListResponseDto;
 import com.ssook.mvc.service.VideoService;
+import com.ssook.mvc.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,10 +17,12 @@ import java.util.Map;
 @RequestMapping("/video")
 public class VideoController {
     private final VideoService videoService;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public VideoController(VideoService videoService) {
+    public VideoController(VideoService videoService, JwtUtil jwtUtil) {
         this.videoService = videoService;
+        this.jwtUtil = jwtUtil;
     }
 
     // 영상 목록 조회
@@ -34,5 +35,17 @@ public class VideoController {
         data.put("videos", videos);
 
         return ApiResponse.success(data);
+    }
+
+    // 영상 상세 조회
+    @GetMapping("/{videoId}")
+    public ApiResponse<VideoDetailResponseDto> getVideoDetail(@PathVariable Long videoId, @RequestHeader("token") String token) {
+        // 토큰에서 유저ID 꺼내기
+        Long userId = jwtUtil.getUserId(token);
+
+        // 영상 상세 정보 가져오기
+        VideoDetailResponseDto videoDetail = videoService.getVideoDetail(videoId, userId);
+
+        return ApiResponse.success(videoDetail);
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/video/response/VideoDetailResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/response/VideoDetailResponseDto.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.dto.video.response;
+
+import lombok.Data;
+
+@Data
+public class VideoDetailResponseDto {
+    private Long videoId;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private String title;
+
+    private Boolean liked; // 내가 좋아요 했는지
+    private Boolean subscribed; // 내가 이 카테고리를 구독했는지
+    private Integer likeCount; // 좋아요 수
+    private Integer commentCount; // 댓글 수
+    private Integer viewCount; // 조회수
+}

--- a/src/main/java/com/ssook/mvc/entity/CommentEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/CommentEntity.java
@@ -1,0 +1,21 @@
+package com.ssook.mvc.entity;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentEntity extends BaseEntity{
+    // PK
+    private Long commentId;
+
+    // FK
+    private Long videoId;
+    private Long userId;
+    private Long parentId; // 대댓글 용
+
+    private String content;
+    private boolean isDeleted = false;
+}

--- a/src/main/java/com/ssook/mvc/entity/ReactionEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/ReactionEntity.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.entity;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactionEntity extends BaseEntity{
+    // PK
+    private Long reactionId;
+
+    // FK
+    private Long userId;
+    private Long videoId;
+}

--- a/src/main/java/com/ssook/mvc/repository/VideoMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/VideoMapper.java
@@ -1,12 +1,21 @@
 package com.ssook.mvc.repository;
 
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
 import com.ssook.mvc.dto.video.response.VideoListResponseDto;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface VideoMapper {
+    // 영상 목록 조회
     List<VideoListResponseDto> selectVideoList(VideoListRequestDto videoListRequestDto);
+
+    // 영상 상세 조회
+    VideoDetailResponseDto selectVideoDetail(@Param("videoId") Long videoId, @Param("userId") Long userId);
+
+    // 조회수 증가
+    void increaseViewCount(Long videoId);
 }

--- a/src/main/java/com/ssook/mvc/service/VideoService.java
+++ b/src/main/java/com/ssook/mvc/service/VideoService.java
@@ -1,6 +1,7 @@
 package com.ssook.mvc.service;
 
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
+import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
 import com.ssook.mvc.dto.video.response.VideoListResponseDto;
 import com.ssook.mvc.repository.VideoMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,5 +26,21 @@ public class VideoService {
             videoListRequestDto.setSortedType(1);
 
         return videoMapper.selectVideoList(videoListRequestDto);
+    }
+
+    // 영상 상세 조회
+    @Transactional
+    public VideoDetailResponseDto getVideoDetail(Long videoId, Long userId) {
+        // 조회수 증가시키기
+        videoMapper.increaseViewCount(videoId);
+
+        // 상세 정보 가져오기
+        VideoDetailResponseDto videoDetail = videoMapper.selectVideoDetail(videoId, userId);
+
+        // 영상이 없으면 예외 return
+        if(videoDetail == null)
+            throw new IllegalArgumentException("해당하는 영상이 존재하지 않습니다.");
+
+        return videoDetail;
     }
 }

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -26,4 +26,23 @@
 
         LIMIT #{size} OFFSET #{offset}
     </select>
+
+    <!-- 영상 상세 조회 -->
+    <select id="selectVideoDetail" resultType="VideoDetailResponseDto">
+        SELECT v.video_id AS videoId, v.video_url AS videoUrl, v.thumbnail_url AS thumbnailUrl, v.title AS title, v.view_count AS viewCount,
+        (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) AS likeCount,
+        (SELECT COUNT(*) FROM comment c WHERE c.video_id = v.video_id AND c.is_deleted = false) AS commentCount,
+        EXISTS(SELECT 1 FROM reaction r WHERE r.video_id = v.video_id AND r.user_id = #{userId}) AS liked,
+        EXISTS(SELECT 1 FROM subscription s WHERE s.category_id = v.category_id AND s.user_id = #{userId}) AS subscribed
+
+        FROM video v
+        WHERE v.video_id = #{videoId}
+    </select>
+    
+    <!-- 조회수 증가 -->
+    <update id="increaseViewCount" parameterType="long">
+        UPDATE video
+        SET view_count = view_count + 1
+        WHERE video_id = #{videoId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 영상 상세 조회 기능 구현

## 👩‍💻 작업 내용
1. 영상 상세 조회 API 구현 (GET /video/{videoId})
    - VideoDetailResponseDto 생성: 영상 정보뿐만 아니라 좋아요 여부, 구독 여부, 좋아요/댓글 수 등을 포함하는 응답 객체 정의
    - MyBatis Mapper 구현: 서브쿼리(Subquery)를 활용하여 영상 상세 정보 조회 시 viewCount, likeCount, commentCount 및 사용자별 liked, subscribed 상태를 한 번에 가져오도록 쿼리 작성
    - 조회수 증가 로직 추가: 상세 조회 시 increaseViewCount 쿼리가 실행되도록 Service 계층에서 트랜잭션 처리

## 🛠️ 기술적 의사결정
- Entity와 DTO의 역할 분리 및 서브쿼리 활용
    - VideoEntity는 DB 테이블(video)과 1:1 매핑을 유지하여 순수성을 지키고, 화면에 필요한 파생 데이터(likeCount, liked 여부 등)는 VideoDetailResponseDto를 통해 처리하도록 분리했습니다.

    - MyBatis의 서브쿼리(Select Subquery)를 사용하여, DB 레벨에서 카운팅(COUNT)과 존재 여부(EXISTS)를 처리한 뒤 DTO에 매핑했습니다. 이를 통해 불필요한 데이터를 애플리케이션 메모리로 로딩하는 것을 방지하고 쿼리 효율성을 높였습니다.

- 토큰 기반의 사용자 상태 확인
    - 단순 영상 정보 조회가 아니라 '현재 로그인한 사용자가 좋아요를 눌렀는지'를 판단해야 하므로, API 요청 헤더(token)에서 JWT를 파싱해 userId를 추출하는 방식을 채택했습니다. 이를 통해 서버 세션 없이도 Stateless하게 사용자별 맞춤 데이터를 제공할 수 있도록 구현했습니다.

## ✅ 테스트 결과
- http://localhost:8080/video/1
<img width="842" height="341" alt="image" src="https://github.com/user-attachments/assets/d2a57015-e957-45e6-a40c-d92f3c798aa1" />


## 🔗 관련 이슈
- #10 