### PR TITLE
feat : 사용자 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.ssook.mvc.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import com.ssook.mvc.common.ApiResponse;
 import com.ssook.mvc.dto.user.UserInfoResponse;
 import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.dto.user.UserLoginRequest;
+import com.ssook.mvc.dto.user.UserModifyRequest;
 import com.ssook.mvc.service.UserService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -47,7 +49,7 @@ public class UserController {
         return ApiResponse.createSuccess("로그인에 성공했습니다.");
     }
     
- // 내 정보 조회 API
+    // 내 정보 조회 API
     @GetMapping("/me")
     public ApiResponse<UserInfoResponse> getMyInfo(HttpServletRequest request) {
         // Interceptor가 넣어둔 "userId"
@@ -59,4 +61,18 @@ public class UserController {
         // 응답 (데이터가 담긴 성공 응답)
         return ApiResponse.success(userInfo);
     }
+    
+ // 내 정보 수정 API
+    @PatchMapping("/me")
+    public ApiResponse<UserInfoResponse> modifyUser(
+            @Valid @RequestBody UserModifyRequest request, 
+            HttpServletRequest httpRequest) { // 변수명 겹칠까봐 httpRequest로 씀
+        
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        
+        UserInfoResponse updatedInfo = userService.modifyUser(userId, request);
+        
+        return ApiResponse.success(updatedInfo);
+    }
+    
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserModifyRequest.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserModifyRequest.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserModifyRequest {
+    
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+    
+    private String intro; // 한줄 소개는 비어있어도 됨 (NotBlank 안 붙임)
+}

--- a/src/main/java/com/ssook/mvc/entity/UserEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/UserEntity.java
@@ -19,4 +19,11 @@ public class UserEntity extends BaseEntity { // 상속
     private String intro;       // DB: intro
     
     // createdAt, updatedAt은 부모(BaseEntity)에 있으므로 생략
+    
+    
+	// 회원 정보 수정 편의 메서드
+    public void modify(String nickname, String intro) {
+        this.nickname = nickname;
+        this.intro = intro;
+    }
 }

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -18,4 +18,6 @@ public interface UserMapper {
     UserEntity findByEmail(String email);
     
     UserEntity findById(Long userId);
+    
+    void updateUser(UserEntity user);
 }

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ssook.mvc.dto.user.UserInfoResponse;
 import com.ssook.mvc.dto.user.UserJoinRequest;
 import com.ssook.mvc.dto.user.UserLoginRequest;
+import com.ssook.mvc.dto.user.UserModifyRequest;
 import com.ssook.mvc.entity.UserEntity;
 import com.ssook.mvc.repository.UserMapper;
 import com.ssook.mvc.util.JwtUtil;
@@ -74,4 +75,29 @@ public class UserService {
         return UserInfoResponse.from(user);
     }
     
+ // 내 정보 수정
+    @Transactional
+    public UserInfoResponse modifyUser(Long userId, UserModifyRequest request) {
+        // 기존 유저 정보 조회
+        UserEntity user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+
+        // 닉네임 중복 검사 (중요: "닉네임이 바뀌었을 때만" 검사해야 함)
+        // 기존 닉네임이랑 다른데(바꿨는데) && DB에 이미 있다면 -> 에러
+        if (!user.getNickname().equals(request.getNickname()) 
+             && userMapper.existsByNickname(request.getNickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // Entity 내용 변경 (아까 만든 modify 메서드 사용)
+        user.modify(request.getNickname(), request.getIntro());
+
+        // DB 업데이트 실행
+        userMapper.updateUser(user);
+
+        // 변경된 최신 정보를 DTO로 변환해서 반환
+        return UserInfoResponse.from(user);
+    }
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -39,5 +39,14 @@
 	<select id="findById" parameterType="long" resultType="com.ssook.mvc.entity.UserEntity">
     SELECT * FROM users WHERE user_id = #{userId}
 	</select>
+	
+	<update id="updateUser" parameterType="com.ssook.mvc.entity.UserEntity">
+    UPDATE users 
+    SET 
+        nickname = #{nickname},
+        intro = #{intro},
+        updated_at = NOW()
+    WHERE user_id = #{userId}
+	</update>
 
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 로그인한 사용자가 자신의 닉네임과 한줄 소개를 수정할 수 있는 기능을 구현했습니다.
- 관련 이슈: #17 

## 👩‍💻 작업 내용
1. **내 정보 수정 API 구현** (`PATCH /users/me`)
   - `UserModifyRequest` DTO를 통해 변경할 닉네임과 소개글 수신
   - `UserService`에서 닉네임 변경 시 중복 여부 체크 로직 수행
   - 본인의 기존 닉네임과 같을 경우 중복 체크 예외 처리

2. **Entity 비즈니스 로직 추가**
   - `modify(nickname, intro)` 메서드를 추가하여, 무분별한 Setter 사용을 지양하고 수정 의도를 명확히 함

3. **MyBatis 매퍼 추가**
   - `updateUser`: 정보 수정 및 `updated_at` 갱신 쿼리 작성

## 🛠️ 기술적 의사결정
- **PATCH Method 사용:** 전체 정보를 갈아끼우는 PUT 대신, 일부 필드만 변경하는 의미에 맞게 PATCH 메서드를 사용했습니다.
- **Entity 메서드 활용:** 서비스 계층에서 엔티티의 필드를 직접 조작(Setter)하는 대신, 엔티티 내부의 수정 메서드를 호출하여 객체지향적인 설계를 지향했습니다.

## ✅ 테스트 결과
- Postman 테스트 완료: 정보 수정 후 200 OK 및 반영된 데이터 응답 확인
- 중복 닉네임 변경 시도 시 예외 발생 확인