### PR TITLE
feat : 사용자 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.ssook.mvc.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -62,7 +64,7 @@ public class UserController {
         return ApiResponse.success(userInfo);
     }
     
- // 내 정보 수정 API
+    // 내 정보 수정 API
     @PatchMapping("/me")
     public ApiResponse<UserInfoResponse> modifyUser(
             @Valid @RequestBody UserModifyRequest request, 
@@ -73,6 +75,29 @@ public class UserController {
         UserInfoResponse updatedInfo = userService.modifyUser(userId, request);
         
         return ApiResponse.success(updatedInfo);
+    }
+    
+    // 회원 탈퇴 API
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Object> deleteUser(
+            @PathVariable Long userId, 
+            HttpServletRequest request) {
+        
+        // 토큰에서 로그인한 사람의 ID 꺼내기
+        Long tokenUserId = (Long) request.getAttribute("userId");
+        
+        // 남의 아이디를 지우려고 하는지 검사
+        // 자바에서 객체 비교는 .equals()를 써야 안전 (== 쓰면 안 됨)
+        if (!tokenUserId.equals(userId)) {
+            // 403 Forbidden 성격이지만, 편의상 예외 메시지로 처리
+            throw new IllegalArgumentException("본인의 계정만 탈퇴할 수 있습니다.");
+        }
+        
+        // 서비스 호출 (삭제)
+        userService.deleteUser(userId);
+        
+        // 성공 응답
+        return ApiResponse.createSuccess("회원 탈퇴가 완료되었습니다.");
     }
     
 }

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -20,4 +20,6 @@ public interface UserMapper {
     UserEntity findById(Long userId);
     
     void updateUser(UserEntity user);
+    
+    void deleteUser(Long userId);
 }

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
         return UserInfoResponse.from(user);
     }
     
- // 내 정보 수정
+	// 내 정보 수정
     @Transactional
     public UserInfoResponse modifyUser(Long userId, UserModifyRequest request) {
         // 기존 유저 정보 조회
@@ -100,4 +100,18 @@ public class UserService {
         // 변경된 최신 정보를 DTO로 변환해서 반환
         return UserInfoResponse.from(user);
     }
+    
+    // 회원 탈퇴
+    @Transactional
+    public void deleteUser(Long userId) {
+        // 존재 여부 확인 (혹시 이미 지워진 아이디일 수도 있으니)
+        UserEntity user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+
+        // 삭제 수행
+        userMapper.deleteUser(userId);
+    }
+    
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -48,5 +48,9 @@
         updated_at = NOW()
     WHERE user_id = #{userId}
 	</update>
+	
+	<delete id="deleteUser" parameterType="long">
+    DELETE FROM users WHERE user_id = #{userId}
+	</delete>
 
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 사용자가 자신의 계정을 삭제(탈퇴)할 수 있는 기능을 구현했습니다.
- 관련 이슈: #25 

## 👩‍💻 작업 내용
1. **회원 탈퇴 API 구현** (`DELETE /users/{userId}`)
   - Path Variable로 삭제할 사용자 ID(`userId`)를 수신
   - 로그인한 사용자(`tokenUserId`)와 삭제 대상(`userId`)이 일치하는지 검증
   - 불일치 시 예외(`IllegalArgumentException`) 처리하여 타인의 계정 삭제 방지

2. **MyBatis 매퍼 추가**
   - `deleteUser`: DB에서 해당 유저 데이터를 완전히 삭제하는 쿼리 작성

## 🛠️ 기술적 의사결정
- **Hard Delete 방식 채택:** - 개인정보 보호 및 데이터 정리 목적을 위해, 탈퇴 시 데이터를 보존하지 않고 즉시 삭제하는 Hard Delete 방식을 선택했습니다.
  - 추후 게시글(Video) 연동 시 `ON DELETE SET NULL` 옵션을 통해 "탈퇴한 사용자"로 처리할 예정입니다.

## ✅ 테스트 결과
- Postman 테스트 완료: 본인 계정 삭제 요청 시 200 OK
- 타인 계정 삭제 시도 시 500 예외 발생 확인