### PR TITLE
Feat: Comment - 댓글 작성 기능과 대댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CommentController.java
+++ b/src/main/java/com/ssook/mvc/controller/CommentController.java
@@ -1,0 +1,47 @@
+package com.ssook.mvc.controller;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.comment.request.CommentRequestDto;
+import com.ssook.mvc.dto.comment.response.CommentResponseDto;
+import com.ssook.mvc.service.CommentService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    // 댓글 작성
+    @PostMapping("/video/{video_id}/comment")
+    public ApiResponse<CommentResponseDto> createComment(
+            @PathVariable("video_id") Long videoId,
+            @RequestBody CommentRequestDto commentRequestDto,
+            HttpServletRequest request
+            ) {
+        // request에서 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 댓글 저장 후 반환받기
+        CommentResponseDto comment = commentService.addComment(videoId, userId, commentRequestDto);
+
+        return new ApiResponse<>(201, "댓글 등록 성공", comment);
+    }
+
+    // 대댓글 작성
+    @PostMapping("/comment/{comment_id}/reply")
+    public ApiResponse<CommentResponseDto> createReply(
+            @PathVariable("comment_id") Long commentId,
+            @RequestBody CommentRequestDto commentRequestDto,
+            HttpServletRequest request
+            ) {
+        // request에서 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 대댓글 저장 후 반환받기
+        CommentResponseDto reply = commentService.addReply(commentId, userId, commentRequestDto);
+
+        return new ApiResponse<>(201, "대댓글 등록 성공", reply);
+    }
+}

--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -3,10 +3,10 @@ package com.ssook.mvc.controller;
 import com.ssook.mvc.common.ApiResponse;
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
 import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
-import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import com.ssook.mvc.dto.video.response.VideoResponseDto;
 import com.ssook.mvc.service.VideoService;
-import com.ssook.mvc.util.JwtUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -15,21 +15,15 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/video")
+@RequiredArgsConstructor
 public class VideoController {
     private final VideoService videoService;
-    private final JwtUtil jwtUtil;
-
-    @Autowired
-    public VideoController(VideoService videoService, JwtUtil jwtUtil) {
-        this.videoService = videoService;
-        this.jwtUtil = jwtUtil;
-    }
 
     // 영상 목록 조회
     @GetMapping
     public ApiResponse<Map<String, Object>> getVideoList(@ModelAttribute VideoListRequestDto videoListRequestDto) {
         // 서비스 호출로 영상 목록 가져와서 videos에 할당
-        List<VideoListResponseDto> videos = videoService.getVideoList(videoListRequestDto);
+        List<VideoResponseDto> videos = videoService.getVideoList(videoListRequestDto);
         // Map에 videos넣기
         Map<String, Object> data = new HashMap<>();
         data.put("videos", videos);
@@ -39,9 +33,9 @@ public class VideoController {
 
     // 영상 상세 조회
     @GetMapping("/{videoId}")
-    public ApiResponse<VideoDetailResponseDto> getVideoDetail(@PathVariable Long videoId, @RequestHeader("token") String token) {
-        // 토큰에서 유저ID 꺼내기
-        Long userId = jwtUtil.getUserId(token);
+    public ApiResponse<VideoDetailResponseDto> getVideoDetail(@PathVariable Long videoId, HttpServletRequest request) {
+        // request에서 유저ID 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
 
         // 영상 상세 정보 가져오기
         VideoDetailResponseDto videoDetail = videoService.getVideoDetail(videoId, userId);

--- a/src/main/java/com/ssook/mvc/dto/comment/request/CommentRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/comment/request/CommentRequestDto.java
@@ -1,0 +1,8 @@
+package com.ssook.mvc.dto.comment.request;
+
+import lombok.Data;
+
+@Data
+public class CommentRequestDto {
+    private String content;
+}

--- a/src/main/java/com/ssook/mvc/dto/comment/response/CommentResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/comment/response/CommentResponseDto.java
@@ -1,0 +1,14 @@
+package com.ssook.mvc.dto.comment.response;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CommentResponseDto {
+    private Long commentId;
+    private Long parentId; // 대댓글일 경우에만 존재
+    private String content; // 댓글 내용
+    private String nickname; // 댓글 단 유저의 닉네임
+    private LocalDateTime createdAt; // 댓글 달린 시간
+}

--- a/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
@@ -3,7 +3,7 @@ package com.ssook.mvc.dto.video.response;
 import lombok.Data;
 
 @Data
-public class VideoListResponseDto {
+public class VideoResponseDto {
     private Long videoId;
     private String thumbnailUrl;
     private Integer viewCount;

--- a/src/main/java/com/ssook/mvc/repository/CommentMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CommentMapper.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.repository;
+
+import com.ssook.mvc.dto.comment.response.CommentResponseDto;
+import com.ssook.mvc.entity.CommentEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CommentMapper {
+    // 댓글 저장
+    void saveComment(CommentEntity commentEntity);
+
+    // 저장된 댓글 조회
+    CommentResponseDto findCommentById(Long commentId);
+
+    // 부모 댓글의 videoId 조회
+    Long findVideoIdByCommentId(Long commentId);
+}

--- a/src/main/java/com/ssook/mvc/repository/VideoMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/VideoMapper.java
@@ -2,7 +2,7 @@ package com.ssook.mvc.repository;
 
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
 import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
-import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import com.ssook.mvc.dto.video.response.VideoResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -11,7 +11,7 @@ import java.util.List;
 @Mapper
 public interface VideoMapper {
     // 영상 목록 조회
-    List<VideoListResponseDto> selectVideoList(VideoListRequestDto videoListRequestDto);
+    List<VideoResponseDto> selectVideoList(VideoListRequestDto videoListRequestDto);
 
     // 영상 상세 조회
     VideoDetailResponseDto selectVideoDetail(@Param("videoId") Long videoId, @Param("userId") Long userId);

--- a/src/main/java/com/ssook/mvc/service/CommentService.java
+++ b/src/main/java/com/ssook/mvc/service/CommentService.java
@@ -1,0 +1,57 @@
+package com.ssook.mvc.service;
+
+import com.ssook.mvc.dto.comment.request.CommentRequestDto;
+import com.ssook.mvc.dto.comment.response.CommentResponseDto;
+import com.ssook.mvc.entity.CommentEntity;
+import com.ssook.mvc.repository.CommentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentMapper commentMapper;
+
+    // 댓글 작성
+    @Transactional
+    public CommentResponseDto addComment(Long videoId, Long userId, CommentRequestDto commentRequestDto) {
+        // CommentEntity 생성
+        CommentEntity commentEntity = CommentEntity.builder()
+                .videoId(videoId)
+                .userId(userId)
+                .content(commentRequestDto.getContent())
+                .build();
+
+        // 댓글 저장
+        commentMapper.saveComment(commentEntity);
+
+        // 저장된 댓글 정보 반환
+        return commentMapper.findCommentById(commentEntity.getCommentId());
+    }
+
+    // 대댓글 작성
+    @Transactional
+    public CommentResponseDto addReply(Long parentId, Long userId, CommentRequestDto commentRequestDto) {
+        // 부모 댓글의 videoId 조회
+        Long videoId = commentMapper.findVideoIdByCommentId(parentId);
+        // 영상이 없을 경우 예외 발생
+        if (videoId == null) {
+            throw new IllegalArgumentException("존재하지 않는 부모 댓글입니다.");
+        }
+
+        // CommentEntity 생성
+        CommentEntity reply = CommentEntity.builder()
+                .videoId(videoId)
+                .userId(userId)
+                .parentId(parentId)
+                .content(commentRequestDto.getContent())
+                .build();
+
+        // 댓글 저장
+        commentMapper.saveComment(reply);
+
+        // 저장된 댓글 정보 반환
+        return commentMapper.findCommentById(reply.getCommentId());
+    }
+}

--- a/src/main/java/com/ssook/mvc/service/VideoService.java
+++ b/src/main/java/com/ssook/mvc/service/VideoService.java
@@ -2,26 +2,23 @@ package com.ssook.mvc.service;
 
 import com.ssook.mvc.dto.video.request.VideoListRequestDto;
 import com.ssook.mvc.dto.video.response.VideoDetailResponseDto;
-import com.ssook.mvc.dto.video.response.VideoListResponseDto;
+import com.ssook.mvc.dto.video.response.VideoResponseDto;
 import com.ssook.mvc.repository.VideoMapper;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class VideoService {
     private final VideoMapper videoMapper;
 
-    @Autowired
-    public VideoService(VideoMapper videoMapper) {
-        this.videoMapper = videoMapper;
-    }
 
     // 영상 목록 조회
     @Transactional
-    public List<VideoListResponseDto> getVideoList(VideoListRequestDto videoListRequestDto) {
+    public List<VideoResponseDto> getVideoList(VideoListRequestDto videoListRequestDto) {
         if(videoListRequestDto.getSortedType() == null)
             videoListRequestDto.setSortedType(1);
 

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssook.mvc.repository.CommentMapper">
+    <!-- 댓글 작성 -->
+    <insert id="saveComment" parameterType="CommentEntity" useGeneratedKeys="true" keyProperty="commentId">
+        INSERT INTO comment(video_id, user_id, parent_id, content, is_deleted)
+        VALUES (#{videoId}, #{userId}, #{parentId}, #{content}, #{isDeleted})
+    </insert>
+
+    <!-- 저장된 댓글 조회 -->
+    <select id="findCommentById" parameterType="Long" resultType="CommentResponseDto">
+        SELECT
+            c.comment_id AS commentId,
+            c.parent_id AS parentId,
+            c.content AS content,
+            u.nickname AS nickname,
+            c.created_at AS createdAt
+        FROM comment c
+        JOIN users u ON c.user_id = u.user_id
+        WHERE c.comment_id = #{commentId}
+    </select>
+
+    <!-- 부모 댓글의 videoId 조회 -->
+    <select id="findVideoIdByCommentId" parameterType="Long" resultType="Long">
+        SELECT video_id
+        FROM comment
+        WHERE comment_id = #{commentId}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="com.ssook.mvc.repository.VideoMapper">
     <!-- 영상 목록 조회 -->
-    <select id="selectVideoList" parameterType="VideoListRequestDto" resultType="VideoListResponseDto">
+    <select id="selectVideoList" parameterType="VideoListRequestDto" resultType="VideoResponseDto">
         SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount
         FROM video v
         LEFT JOIN category c ON v.category_id = c.category_id


### PR DESCRIPTION
## 📌 개요
- Comment 도메인의 댓글과 대댓글 작성 기능 구현

## 👩‍💻 작업 내용
1. 댓글 작성 기능
    - 특정 영상에 대한 댓글을 작성하는 기능을 구현
3. 대댓글 작성 기능
    - 특정 댓글의 하위 답글(대댓글)을 작성하는 기능을 구현
    - 부모 댓글의 존재 여부를 검증하고, 동일한 영상 ID(videoId)를 가지도록 처리

## 🛠️ 기술적 의사결정
- RESTful API 설계
    - 대댓글의 경우 URL 깊이(Depth)가 너무 깊어지지 않도록, 영상 ID 대신 부모 댓글 ID를 루트로 하는 /comments/{commentId}/reply 구조를 선택
- MyBatis useGeneratedKeys 및 JOIN 활용
    - 댓글 저장 직후 생성된 PK(comment_id)와 nickname이 필요함
    - insert 후 select 문을 실행해 users 테이블과 조인(Join)된 완전한 데이터(닉네임 포함)를 반환하도록 로직을 구성

## ✅ 테스트 결과
- http://localhost:8080/video/4/comment
<img width="493" height="202" alt="스크린샷 2025-12-14 125315" src="https://github.com/user-attachments/assets/66d642ae-8519-46ae-9e22-18ed27cd85e4" />

- http://localhost:8080/comment/3/reply
<img width="397" height="201" alt="스크린샷 2025-12-14 125323" src="https://github.com/user-attachments/assets/64ac9adb-a233-4171-9b30-fb273ad80792" />


## 🔗 관련 이슈
- #20, #21 