### PR TITLE
feat : 카테고리 목록 조회 API 및 공통 페이징 DTO 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CategoryController.java
+++ b/src/main/java/com/ssook/mvc/controller/CategoryController.java
@@ -1,0 +1,31 @@
+package com.ssook.mvc.controller;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.category.response.CategoryResponseDto;
+import com.ssook.mvc.dto.common.PageResponse;
+import com.ssook.mvc.service.CategoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<CategoryResponseDto>> getCategoryList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int perPage, 
+            HttpServletRequest request) {
+        
+        // 인터셉터가 넣어준 userId 꺼내기 (비로그인 시 null일 수 있음)
+        Long userId = (Long) request.getAttribute("userId");
+        
+        PageResponse<CategoryResponseDto> response = categoryService.getCategoryList(page, perPage, userId);
+        
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
@@ -1,0 +1,28 @@
+package com.ssook.mvc.dto.category.response;
+
+import com.ssook.mvc.entity.CategoryEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Builder
+public class CategoryResponseDto {
+    private Integer categoryId;
+    private String name;
+    private String imageUrl;
+    private String description;
+    
+    @Setter
+    private Boolean isSubscribed; 
+
+    public static CategoryResponseDto from(CategoryEntity entity) {
+        return CategoryResponseDto.builder()
+                .categoryId(entity.getCategoryId())
+                .name(entity.getCategoryName())
+                .imageUrl(entity.getImageUrl()) 
+                .description(entity.getDescription())
+                .isSubscribed(false) // 기본값 false (구독 구현 전)
+                .build();
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/common/PageInfo.java
+++ b/src/main/java/com/ssook/mvc/dto/common/PageInfo.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.dto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PageInfo {
+    private int page;         // 현재 페이지
+    private int perPage;      // 페이지당 개수
+    private int totalCount;   // 전체 데이터 개수
+    private int totalPages;   // 전체 페이지 수
+    private boolean hasNext;  // 다음 페이지 유무
+    private boolean hasPrev;  // 이전 페이지 유무
+}

--- a/src/main/java/com/ssook/mvc/dto/common/PageResponse.java
+++ b/src/main/java/com/ssook/mvc/dto/common/PageResponse.java
@@ -1,0 +1,26 @@
+package com.ssook.mvc.dto.common;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PageResponse<T> {
+    private List<T> content;
+    private PageInfo pageInfo;
+
+    public PageResponse(List<T> content, int page, int size, int totalCount) {
+        this.content = content;
+        
+        // 총 페이지 수 계산 (나눗셈 올림 처리)
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+
+        this.pageInfo = PageInfo.builder()
+                .page(page)
+                .perPage(size)
+                .totalCount(totalCount)
+                .totalPages(totalPages)
+                .hasNext(page < totalPages)
+                .hasPrev(page > 1)
+                .build();
+    }
+}

--- a/src/main/java/com/ssook/mvc/entity/CategoryEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/CategoryEntity.java
@@ -1,0 +1,15 @@
+package com.ssook.mvc.entity;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryEntity extends BaseEntity {
+    private Integer categoryId;    // DB: INT
+    private Integer parentId;      // DB: INT (상위 카테고리)
+    private String categoryName;   // DB: VARCHAR
+    private String description;    // DB: VARCHAR
+    private String imageUrl;       // DB: VARCHAR
+}

--- a/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
@@ -1,0 +1,15 @@
+package com.ssook.mvc.repository;
+
+import com.ssook.mvc.entity.CategoryEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+@Mapper
+public interface CategoryMapper {
+    // 목록 조회 (페이징 적용)
+    List<CategoryEntity> selectCategoryList(@Param("offset") int offset, @Param("limit") int limit);
+
+    // 전체 개수 (페이징 계산용)
+    int countCategory();
+}

--- a/src/main/java/com/ssook/mvc/service/CategoryService.java
+++ b/src/main/java/com/ssook/mvc/service/CategoryService.java
@@ -1,0 +1,44 @@
+package com.ssook.mvc.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ssook.mvc.dto.category.response.CategoryResponseDto;
+import com.ssook.mvc.dto.common.PageResponse;
+import com.ssook.mvc.entity.CategoryEntity;
+import com.ssook.mvc.repository.CategoryMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryMapper categoryMapper;
+
+    @Transactional(readOnly = true)
+    public PageResponse<CategoryResponseDto> getCategoryList(int page, int size, Long userId) {
+        // 페이징 계산 (offset = (페이지-1) * 개수)
+        int offset = (page - 1) * size;
+
+        // DB 조회
+        List<CategoryEntity> entities = categoryMapper.selectCategoryList(offset, size);
+        int totalCount = categoryMapper.countCategory();
+
+        // Entity -> DTO 변환
+        List<CategoryResponseDto> content = entities.stream()
+                .map(CategoryResponseDto::from)
+                .collect(Collectors.toList());
+
+        // 추후 Subscription 기능 구현 시, userId로 구독 여부 체크 로직 추가 예정
+        if (userId != null) {
+            // 여기에 로직 들어갈 자리
+        }
+
+        // 공통 페이징 객체에 담아 반환
+        return new PageResponse<>(content, page, size, totalCount);
+    }
+}

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssook.mvc.repository.CategoryMapper">
+    
+    <select id="selectCategoryList" resultType="com.ssook.mvc.entity.CategoryEntity">
+        SELECT * FROM category
+        ORDER BY category_id ASC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countCategory" resultType="int">
+        SELECT COUNT(*) FROM category
+    </select>
+    
+</mapper>


### PR DESCRIPTION
## 📌 개요
- 메인 화면과 GNB에 사용할 **카테고리 전체 목록 조회 API**를 구현했습니다.
- 데이터 확장을 대비하여 **페이지네이션(Pagination)** 기능을 적용했습니다.

## 👩‍💻 작업 내용
1. **DB 및 Entity**
   - `CategoryEntity`: `image_url`, `description` 컬럼 추가 반영
   - `BaseEntity` 상속 적용

2. **DTO (Data Transfer Object)**
   - `PageInfo`, `PageResponse<T>`: 프로젝트 전반에서 사용할 공통 페이징 Wrapper 클래스 구현 (`dto.common`)
   - `CategoryResponseDto`: 추후 구독 기능 연동을 위해 `isSubscribed` 필드 확보 (현재 `false` 고정)

3. **API 구현 (`GET /category`)**
   - `CategoryMapper`: `LIMIT`, `OFFSET`을 활용한 페이징 쿼리 및 `count` 쿼리 작성
   - `CategoryService`: 요청된 페이지와 개수에 맞춰 데이터를 가공하여 반환

## 🛠️ 기술적 의사결정
- **Generic PageResponse:** `Video`, `Comment` 등 다른 도메인에서도 페이징 응답 규격을 통일하기 위해 제네릭(`<T>`)으로 설계했습니다.
- **DB 컬럼 추가:** 기획 명세에 맞춰 `description`, `image_url` 컬럼을 DB에 추가하고 Entity에 반영했습니다.

## ✅ 테스트 결과
- Postman 테스트 완료: `page`, `perPage` 파라미터에 따라 데이터가 분할되어 응답됨을 확인.
- JSON 응답 내 `pageInfo` 메타데이터가 정상적으로 계산됨을 확인.

## 🔗 관련 이슈
- Parent: #29
- Closes #30