### PR TITLE
feat : 카테고리 상세 조회

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CategoryController.java
+++ b/src/main/java/com/ssook/mvc/controller/CategoryController.java
@@ -1,12 +1,18 @@
 package com.ssook.mvc.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ssook.mvc.common.ApiResponse;
 import com.ssook.mvc.dto.category.response.CategoryResponseDto;
 import com.ssook.mvc.dto.common.PageResponse;
 import com.ssook.mvc.service.CategoryService;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/category")
@@ -25,6 +31,19 @@ public class CategoryController {
         Long userId = (Long) request.getAttribute("userId");
         
         PageResponse<CategoryResponseDto> response = categoryService.getCategoryList(page, perPage, userId);
+        
+        return ApiResponse.success(response);
+    }
+    
+    @GetMapping("/{categoryId}")
+    public ApiResponse<CategoryResponseDto> getCategoryDetail(
+            @PathVariable Integer categoryId,
+            HttpServletRequest request) {
+        
+        // 상세 조회에서도 '내가 구독했는지' 보여줘야 하므로 userId를 꺼냅니다.
+        Long userId = (Long) request.getAttribute("userId");
+        
+        CategoryResponseDto response = categoryService.getCategoryDetail(categoryId, userId);
         
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
@@ -12,4 +12,7 @@ public interface CategoryMapper {
 
     // 전체 개수 (페이징 계산용)
     int countCategory();
+    
+    // 상세 조회
+    CategoryEntity selectCategoryById(Integer categoryId);
 }

--- a/src/main/java/com/ssook/mvc/service/CategoryService.java
+++ b/src/main/java/com/ssook/mvc/service/CategoryService.java
@@ -41,4 +41,24 @@ public class CategoryService {
         // 공통 페이징 객체에 담아 반환
         return new PageResponse<>(content, page, size, totalCount);
     }
+    
+    // 카테고리 상세 조회
+    @Transactional(readOnly = true)
+    public CategoryResponseDto getCategoryDetail(Integer categoryId, Long userId) {
+        // DB 조회
+        CategoryEntity category = categoryMapper.selectCategoryById(categoryId);
+
+        // 예외 처리 (데이터가 없으면 정지)
+        if (category == null) {
+            throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+        }
+
+        // DTO 변환
+        CategoryResponseDto dto = CategoryResponseDto.from(category);
+
+        // 나중에 여기에 구독 여부 체크 로직(Subscription) 추가
+        // if (userId != null) { ... }
+
+        return dto;
+    }
 }

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -14,4 +14,9 @@
         SELECT COUNT(*) FROM category
     </select>
     
+    <select id="selectCategoryById" parameterType="int" resultType="com.ssook.mvc.entity.CategoryEntity">
+    SELECT * FROM category 
+    WHERE category_id = #{categoryId}
+</select>
+    
 </mapper>


### PR DESCRIPTION
## 📌 개요
- 특정 카테고리의 상세 정보를 조회하는 API(`GET /category/{id}`)를 구현했습니다.
- 존재하지 않는 카테고리 ID 요청 시 예외 처리 로직을 추가했습니다.

## 👩‍💻 작업 내용
1. **Mapper (`CategoryMapper`)**
   - `selectCategoryById`: PK(`category_id`)를 기준으로 단건 데이터를 조회하는 쿼리 작성

2. **Service (`CategoryService`)**
   - 조회 결과가 `null`일 경우 `IllegalArgumentException`을 발생시켜 적절한 에러 응답 유도
   - 추후 구독 기능 연동을 위한 `userId` 파라미터 및 로직 위치 확보

3. **Controller (`CategoryController`)**
   - `@PathVariable`을 사용하여 URL 경로의 ID 값을 받아 Service에 전달

## ✅ 테스트 결과
- **성공:** 유효한 ID 요청 시(예: `/category/1`), 해당 카테고리 정보(이름, 설명, 이미지 등) 정상 반환 확인.
- **실패:** 존재하지 않는 ID 요청 시(예: `/category/999`), 500 Error 및 예외 메시지 반환 확인.

## 🔗 관련 이슈
- Parent: #29
- Closes #31