### PR TITLE
Feat: Comment - 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CommentController.java
+++ b/src/main/java/com/ssook/mvc/controller/CommentController.java
@@ -61,4 +61,21 @@ public class CommentController {
 
         return ApiResponse.success(comments);
     }
+
+    // 댓글 수정
+    @PatchMapping("/comment/{commentId}")
+    public ApiResponse<Object> modifyComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentRequestDto commentRequestDto,
+            HttpServletRequest request
+    ) {
+        // request에서 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 서비스 호출
+        commentService.modifyComment(commentId, userId, commentRequestDto);
+
+        // 3. 응답 반환 (명세서: status 201, message "댓글이 수정되었습니다.")
+        return ApiResponse.createSuccess("댓글이 수정되었습니다.");
+        }
 }

--- a/src/main/java/com/ssook/mvc/repository/CommentMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CommentMapper.java
@@ -28,4 +28,7 @@ public interface CommentMapper {
 
     // 전체 부모 댓글 개수
     int countParentComments(Long videoId);
+
+    // 댓글 수정
+    void updateComment(CommentEntity commentEntity);
 }

--- a/src/main/java/com/ssook/mvc/service/CommentService.java
+++ b/src/main/java/com/ssook/mvc/service/CommentService.java
@@ -103,6 +103,28 @@ public class CommentService {
         return new PageResponse<>(parents, page, size, totalCount);
     }
 
+    // 댓글 수정
+    @Transactional
+    public void modifyComment(Long commentId, Long userId, CommentRequestDto commentRequestDto) {
+        // 1. 댓글 존재 여부 확인
+        CommentResponseDto isExistingComment = commentMapper.findCommentById(commentId);
+        if (isExistingComment == null) {
+            throw new IllegalArgumentException("존재하지 않는 댓글입니다.");
+        }
+
+        // 2. 작성자 본인 확인
+        if (!isExistingComment.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 댓글만 수정할 수 있습니다.");
+        }
+
+        // 3. 댓글 업데이트
+        CommentEntity updateEntity = CommentEntity.builder()
+                .commentId(commentId)
+                .content(commentRequestDto.getContent())
+                .build();
+
+        commentMapper.updateComment(updateEntity);
+    }
 
 
 

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -72,4 +72,13 @@
         FROM comment
         WHERE video_id = #{videoId} AND parent_id IS NULL
     </select>
+
+    <!-- 댓글 수정 -->
+    <update id="updateComment" parameterType="CommentEntity">
+        UPDATE comment
+        SET
+            content = #{content},
+            updated_at = NOW()
+        WHERE comment_id = #{commentId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 개요
- Comment 도메인의 댓글 수정 기능 구현

## 👩‍💻 작업 내용
1. 댓글 수정 API 구현 (PATCH /comments/{commentId})
    - Service: CommentService에 댓글 존재 여부 확인 및 작성자 본인 검증 로직을 추가

## 🛠️ 기술적 의사결정
1. HTTP Method로 PATCH 채택 
    - 댓글 리소스 전체를 갈아끼우는(PUT) 것이 아니라, 내용(content)만 부분적으로 업데이트하는 작업이므로 PATCH 메서드를 사용하여 RESTful한 설계를 따르고 API 명세서를 준수
2. ApiResponse<Object> 제네릭 타입 유지 
    - ApiResponse.createSuccess 메서드가 내부적으로 data 필드에 빈 리스트([])를 반환하도록 구현. 이를 ApiResponse<String>으로 변경할 경우 타입 불일치 및 런타임 캐스팅 에러가 발생할 위험이 있어, Object 타입을 유지하여 안정성을 확보하고 API 명세("data": []) 준수
3. Service 계층에서의 소유권 검증
    - SQL 레벨이나 Controller에서 처리하기보다, 비즈니스 로직을 담당하는 CommentService에서 '댓글 작성자'와 '요청자'의 ID 일치 여부를 검증하도록 구현. 이를 통해 인가되지 않은 사용자의 무단 수정을 방지

## ✅ 테스트 결과
- [Patch] http://localhost:8080/comment/19
<img width="324" height="117" alt="image" src="https://github.com/user-attachments/assets/ea6e8105-4f15-4bad-b1fd-4faa1a779605" />
<img width="274" height="74" alt="image" src="https://github.com/user-attachments/assets/18dba4fe-2f90-4757-8584-5d19bc33b69e" />
<img width="765" height="22" alt="image" src="https://github.com/user-attachments/assets/d5e2a84c-3493-4580-a7f4-d730f0dd3cfb" />


## 🔗 관련 이슈
- #23 