### PR TITLE
Feat: Comment - 댓글 삭제 기능

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CommentController.java
+++ b/src/main/java/com/ssook/mvc/controller/CommentController.java
@@ -75,7 +75,20 @@ public class CommentController {
         // 서비스 호출
         commentService.modifyComment(commentId, userId, commentRequestDto);
 
-        // 3. 응답 반환 (명세서: status 201, message "댓글이 수정되었습니다.")
+        // 3. 응답 반환 (status 201, message "댓글이 수정되었습니다.")
         return ApiResponse.createSuccess("댓글이 수정되었습니다.");
-        }
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/comment/{commentId}")
+    public ApiResponse<Object> deleteComment(@PathVariable("commentId") Long commentId, HttpServletRequest request) {
+        // request에서 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 서비스 호출
+        commentService.deleteComment(commentId, userId);
+
+        // 응답 반환 (status 201, message "댓글이 삭제되었습니다.")
+        return ApiResponse.createSuccess("댓글이 삭제되었습니다");
+    }
 }

--- a/src/main/java/com/ssook/mvc/repository/CommentMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CommentMapper.java
@@ -31,4 +31,7 @@ public interface CommentMapper {
 
     // 댓글 수정
     void updateComment(CommentEntity commentEntity);
+
+    // 댓글 삭제
+    void deleteComment(Long commentId);
 }

--- a/src/main/java/com/ssook/mvc/service/CommentService.java
+++ b/src/main/java/com/ssook/mvc/service/CommentService.java
@@ -126,7 +126,23 @@ public class CommentService {
         commentMapper.updateComment(updateEntity);
     }
 
+    // 댓글 삭제
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        // 1. 댓글 존재 여부 확인
+        CommentResponseDto existingComment = commentMapper.findCommentById(commentId);
+        if (existingComment == null) {
+            throw new IllegalArgumentException("존재하지 않는 댓글입니다.");
+        }
 
+        // 2. 작성자 본인 확인
+        if (!existingComment.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+
+        // 3. 삭제
+        commentMapper.deleteComment(commentId);
+    }
 
     // 현재 내 Id와 댓글의 Id가 일치하는지 체크하는 보조 메서드
     private void checkIsMyComment(CommentResponseDto commentResponseDto, Long userId) {

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -81,4 +81,13 @@
             updated_at = NOW()
         WHERE comment_id = #{commentId}
     </update>
+
+    <!-- 댓글 삭제 -->
+    <delete id="deleteComment" parameterType="Long">
+        UPDATE comment
+        SET
+            is_deleted = true,
+            updated_at = NOW()
+        WHERE comment_id = #{commentId}
+    </delete>
 </mapper>


### PR DESCRIPTION
## 📌 개요
- Comment 도메인의 댓글 삭제 기능 구현

## 👩‍💻 작업 내용
1. 댓글 삭제 API 구현 (DELETE /comment/{commentId})
2. Soft Delete (논리적 삭제) 적용
    - DB에서 행을 물리적으로 제거(DELETE)하는 대신, is_deleted 컬럼을 true로 업데이트하고 updated_at을 갱신하는 방식으로 구현

## 🛠️ 기술적 의사결정
1. Soft Delete 방식 채택
    - 댓글 데이터를 영구 삭제하는 대신 is_deleted 플래그를 사용하여 비활성화하는 방식을 선택. 이를 통해 실수로 인한 데이터 손실을 방지하고, 추후 데이터 복구 가능성이나 감사(Audit) 목적을 위해 데이터를 보존하도록 설계
2. Service 계층에서의 소유권 검증
    - 삭제 요청 시 클라이언트가 보낸 토큰(userId)과 DB에 저장된 댓글 작성자(userId)를 비교하는 로직을 Service 계층에 구현. 이를 통해 본인이 작성한 댓글만 삭제할 수 있도록 보안을 강화

## ✅ 테스트 결과
- [DELETE] http://localhost:8080/comment/19
<img width="323" height="121" alt="image" src="https://github.com/user-attachments/assets/08978d10-d596-4766-9be7-0a703c600969" /><br>
<img width="768" height="137" alt="image" src="https://github.com/user-attachments/assets/7e06d181-5737-4741-81c7-1db9715addfb" /><br>
- comment_id가 19번인 댓글의 is_deleted가 1로 바뀐 모습

## 🔗 관련 이슈
- #24 