### PR TITLE
Feat: Reaction - 좋아요 등록 및 취소

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/ReactionController.java
+++ b/src/main/java/com/ssook/mvc/controller/ReactionController.java
@@ -1,0 +1,31 @@
+package com.ssook.mvc.controller;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.dto.reaction.response.LikeResponseDto;
+import com.ssook.mvc.service.ReactionService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReactionController {
+    private final ReactionService reactionService;
+
+    // 좋아요 등록 및 취소
+    @PostMapping("/video/{videoId}/like")
+    public ApiResponse<LikeResponseDto> toggleLike(
+            @PathVariable("videoId") Long videoId,
+            HttpServletRequest request
+    ) {
+        // request에서 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 서비스 호츨
+        LikeResponseDto likeResponseDto = reactionService.toggleLike(userId, videoId);
+
+        return new ApiResponse<>(200, "성공", likeResponseDto);
+    }
+}

--- a/src/main/java/com/ssook/mvc/dto/reaction/response/LikeResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/reaction/response/LikeResponseDto.java
@@ -1,0 +1,11 @@
+package com.ssook.mvc.dto.reaction.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LikeResponseDto {
+    private boolean liked; // 좋아요 여부(true / false)
+    private int likeCount; // 좋아요 수
+}

--- a/src/main/java/com/ssook/mvc/repository/ReactionMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/ReactionMapper.java
@@ -1,0 +1,19 @@
+package com.ssook.mvc.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ReactionMapper {
+    // 좋아요 존재 여부 확인 (1: 존재, 0: 없음 -> boolean 자동 변환)
+    boolean existReaction(@Param("userId") Long userId, @Param("videoId") Long videoId);
+
+    // 좋아요 추가 (INSERT)
+    void insertReaction(@Param("userId") Long userId, @Param("videoId") Long videoId);
+
+    // 좋아요 취소 (DELETE)
+    void deleteReaction(@Param("userId") Long userId, @Param("videoId") Long videoId);
+
+    // 영상의 총 좋아요 수 조회
+    int countReaction(Long videoId);
+}

--- a/src/main/java/com/ssook/mvc/service/ReactionService.java
+++ b/src/main/java/com/ssook/mvc/service/ReactionService.java
@@ -1,0 +1,40 @@
+package com.ssook.mvc.service;
+
+import com.ssook.mvc.dto.reaction.response.LikeResponseDto;
+import com.ssook.mvc.repository.ReactionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionService {
+    private final ReactionMapper reactionMapper;
+
+    // 좋아요 있으면 -> 좋아요 삭제
+    // 좋아요 없으면 -> 좋아요 추가
+    @Transactional
+    public LikeResponseDto toggleLike(Long userId, Long videoId) {
+        // 좋아요 존재 여부 체크
+        boolean isLiked = reactionMapper.existReaction(userId, videoId);
+
+        if(isLiked) {
+            // 이미 좋아요 존재 -> 삭제
+            reactionMapper.deleteReaction(userId, videoId);
+            isLiked = false;
+        } else {
+            // 좋아요 없음 -> 추가
+            reactionMapper.insertReaction(userId, videoId);
+            isLiked = true;
+        }
+
+        // 좋아요 개수 조회
+        int likeCount = reactionMapper.countReaction(videoId);
+
+        // 결과 반환
+        return LikeResponseDto.builder()
+                .liked(isLiked)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/resources/mapper/ReactionMapper.xml
+++ b/src/main/resources/mapper/ReactionMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssook.mvc.repository.ReactionMapper">
+    <!-- 영상에 내가 단 댓글이 있는지 -->
+    <select id="existReaction" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM reaction
+            WHERE user_id = #{userId} AND video_id = #{videoId}
+        )
+    </select>
+
+    <!-- 좋아요 추가 -->
+    <insert id="insertReaction">
+        INSERT INTO reaction (user_id, video_id)
+        VALUES (#{userId}, #{videoId})
+    </insert>
+
+    <!-- 좋아요 삭제 -->
+    <delete id="deleteReaction">
+        DELETE FROM reaction
+        WHERE user_id = #{userId} AND video_id = #{videoId}
+    </delete>
+    
+    <!-- 좋아요 개수 조회 -->
+    <select id="countReaction" resultType="int">
+        SELECT COUNT(*)
+        FROM reaction
+        WHERE video_id = #{videoId}
+    </select>
+</mapper>


### PR DESCRIPTION
## 📌 개요
- Reaction 도메인 내 좋아요 등록 및 취소 기능 개발

## 👩‍💻 작업 내용
1. 좋아요 토글 API 구현 (POST /video/{videoId}/like)

## 🛠️ 기술적 의사결정
1. Service 계층에서의 토글 로직 처리
    - '조회 → 분기(등록/삭제) → 집계'로 이어지는 일련의 과정을 ReactionService의 하나의 트랜잭션(@Transactional) 안에서 처리. 이를 통해 데이터 정합성을 보장하고, 컨트롤러는 비즈니스 로직을 모른 채 요청/응답만 담당하도록 역할을 명확히 분리

## ✅ 테스트 결과
- http://localhost:8080/video/1/like
- 좋아요 등록
<img width="218" height="170" alt="스크린샷 2025-12-17 231758" src="https://github.com/user-attachments/assets/ba860cba-fcc1-47b2-a728-7be6af133316" /><br>
<img width="413" height="116" alt="스크린샷 2025-12-17 231811" src="https://github.com/user-attachments/assets/683d1104-f262-4bf6-84ca-32ecc851fd37" /><br>
- 좋아요 취소
<img width="232" height="172" alt="스크린샷 2025-12-17 231818" src="https://github.com/user-attachments/assets/71e5e039-b0f6-4aa8-926d-8c174f0b3edd" /><br>
<img width="411" height="93" alt="스크린샷 2025-12-17 231825" src="https://github.com/user-attachments/assets/e6ebde2b-5349-4c21-b4e7-ba264ea8781a" />

## 🔗 관련 이슈
- #39 