### PR TITLE
feat : 구독 등록 및 취소 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/SubscriptionController.java
+++ b/src/main/java/com/ssook/mvc/controller/SubscriptionController.java
@@ -1,0 +1,35 @@
+package com.ssook.mvc.controller;
+
+import com.ssook.mvc.common.ApiResponse;
+import com.ssook.mvc.service.SubscriptionService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/subscription")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    // 구독하기
+    @PostMapping("/{categoryId}")
+    public ApiResponse<Object> subscribe(@PathVariable Integer categoryId, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        
+        subscriptionService.subscribe(userId, categoryId);
+        
+        return ApiResponse.createSuccess("카테고리를 구독했습니다.");
+    }
+
+    // 구독 취소하기
+    @DeleteMapping("/{categoryId}")
+    public ApiResponse<Object> unsubscribe(@PathVariable Integer categoryId, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        
+        subscriptionService.unsubscribe(userId, categoryId);
+        
+        return ApiResponse.createSuccess("구독을 취소했습니다.");
+    }
+}

--- a/src/main/java/com/ssook/mvc/entity/SubscriptionEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/SubscriptionEntity.java
@@ -1,0 +1,17 @@
+package com.ssook.mvc.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubscriptionEntity {
+    private Long subscriptionId; // PK
+    private Long userId;         // 구독한 유저
+    private Integer categoryId;  // 구독된 카테고리 (CategoryEntity가 Integer)
+    
+}

--- a/src/main/java/com/ssook/mvc/repository/SubscriptionMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/SubscriptionMapper.java
@@ -1,0 +1,22 @@
+package com.ssook.mvc.repository;
+
+import com.ssook.mvc.entity.SubscriptionEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface SubscriptionMapper {
+    // 구독 추가
+    void insertSubscription(SubscriptionEntity subscriptionEntity);
+
+    // 구독 취소
+    void deleteSubscription(@Param("userId") Long userId, @Param("categoryId") Integer categoryId);
+
+    // 이미 구독했는지 확인 (중복 방지용)
+    boolean existsSubscription(@Param("userId") Long userId, @Param("categoryId") Integer categoryId);
+
+    // 내가 구독한 카테고리 ID 목록 조회 (CategoryService에서 사용 예정)
+    List<Integer> selectSubscribedCategoryIds(Long userId);
+}

--- a/src/main/java/com/ssook/mvc/service/CategoryService.java
+++ b/src/main/java/com/ssook/mvc/service/CategoryService.java
@@ -1,6 +1,8 @@
 package com.ssook.mvc.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +12,7 @@ import com.ssook.mvc.dto.category.response.CategoryResponseDto;
 import com.ssook.mvc.dto.common.PageResponse;
 import com.ssook.mvc.entity.CategoryEntity;
 import com.ssook.mvc.repository.CategoryMapper;
+import com.ssook.mvc.repository.SubscriptionMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class CategoryService {
 
     private final CategoryMapper categoryMapper;
+    private final SubscriptionMapper subscriptionMapper;
 
     @Transactional(readOnly = true)
     public PageResponse<CategoryResponseDto> getCategoryList(int page, int size, Long userId) {
@@ -33,9 +37,21 @@ public class CategoryService {
                 .map(CategoryResponseDto::from)
                 .collect(Collectors.toList());
 
-        // 추후 Subscription 기능 구현 시, userId로 구독 여부 체크 로직 추가 예정
-        if (userId != null) {
-            // 여기에 로직 들어갈 자리
+        // 구독 여부 체크 로직
+        if (userId != null && !content.isEmpty()) {
+            // 내가 구독한 카테고리 ID 목록을 가져옴 (예: [1, 3, 5])
+            List<Integer> subscribedIds = subscriptionMapper.selectSubscribedCategoryIds(userId);
+            
+            // 비교하기 쉽게 Set으로 변환 (검색 속도 O(1))
+            // import java.util.Set; import java.util.HashSet;
+            Set<Integer> subscribedSet = new HashSet<>(subscribedIds); 
+
+            // 리스트를 돌면서 ID가 Set에 있으면 isSubscribed = true
+            for (CategoryResponseDto dto : content) {
+                if (subscribedSet.contains(dto.getCategoryId())) {
+                    dto.setIsSubscribed(true);
+                }
+            }
         }
 
         // 공통 페이징 객체에 담아 반환
@@ -56,8 +72,11 @@ public class CategoryService {
         // DTO 변환
         CategoryResponseDto dto = CategoryResponseDto.from(category);
 
-        // 나중에 여기에 구독 여부 체크 로직(Subscription) 추가
-        // if (userId != null) { ... }
+        // 상세 조회 시 구독 여부 체크
+        if (userId != null) {
+            boolean isSubscribed = subscriptionMapper.existsSubscription(userId, categoryId);
+            dto.setIsSubscribed(isSubscribed);
+        }
 
         return dto;
     }

--- a/src/main/java/com/ssook/mvc/service/SubscriptionService.java
+++ b/src/main/java/com/ssook/mvc/service/SubscriptionService.java
@@ -1,0 +1,50 @@
+package com.ssook.mvc.service;
+
+import com.ssook.mvc.entity.SubscriptionEntity;
+import com.ssook.mvc.repository.CategoryMapper;
+import com.ssook.mvc.repository.SubscriptionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+    private final SubscriptionMapper subscriptionMapper;
+    private final CategoryMapper categoryMapper; // 카테고리 존재 확인용
+
+    // 구독하기
+    @Transactional
+    public void subscribe(Long userId, Integer categoryId) {
+        // 존재하지 않는 카테고리면 에러
+        if (categoryMapper.selectCategoryById(categoryId) == null) {
+            throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+        }
+
+        // 이미 구독 중이면 에러 (혹은 무시)
+        if (subscriptionMapper.existsSubscription(userId, categoryId)) {
+            throw new IllegalArgumentException("이미 구독 중인 카테고리입니다.");
+        }
+
+        // 저장
+        SubscriptionEntity subscription = SubscriptionEntity.builder()
+                .userId(userId)
+                .categoryId(categoryId)
+                .build();
+        
+        subscriptionMapper.insertSubscription(subscription);
+    }
+
+    // 구독 취소하기
+    @Transactional
+    public void unsubscribe(Long userId, Integer categoryId) {
+        // 구독 내역이 없으면 에러
+        if (!subscriptionMapper.existsSubscription(userId, categoryId)) {
+            throw new IllegalArgumentException("구독 중인 카테고리가 아닙니다.");
+        }
+
+        // 삭제
+        subscriptionMapper.deleteSubscription(userId, categoryId);
+    }
+}

--- a/src/main/resources/mapper/SubscriptionMapper.xml
+++ b/src/main/resources/mapper/SubscriptionMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ssook.mvc.repository.SubscriptionMapper">
+
+    <insert id="insertSubscription" parameterType="com.ssook.mvc.entity.SubscriptionEntity">
+        INSERT INTO subscription (user_id, category_id)
+        VALUES (#{userId}, #{categoryId})
+    </insert>
+
+    <delete id="deleteSubscription">
+        DELETE FROM subscription
+        WHERE user_id = #{userId} AND category_id = #{categoryId}
+    </delete>
+
+    <select id="existsSubscription" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM subscription
+            WHERE user_id = #{userId} AND category_id = #{categoryId}
+        )
+    </select>
+
+    <select id="selectSubscribedCategoryIds" resultType="int">
+        SELECT category_id
+        FROM subscription
+        WHERE user_id = #{userId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌 개요
- 사용자가 카테고리를 구독(`POST`)하거나 구독을 취소(`DELETE`)하는 API를 구현했습니다.
- 중복 구독 방지 및 존재하지 않는 대상에 대한 예외 처리를 적용했습니다.

## 👩‍💻 작업 내용
1. **Mapper (`SubscriptionMapper`)**
   - `insertSubscription`: 구독 정보를 DB에 저장하는 쿼리 작성 (복합 유니크 키 제약조건 고려)
   - `deleteSubscription`: 구독 정보를 DB에서 삭제하는 쿼리 작성
   - `existsSubscription`: 이미 구독 중인지 확인하는 조회 쿼리 작성

2. **Service (`SubscriptionService`)**
   - **구독 등록:** 
     - 이미 구독한 상태라면 예외(`IllegalStateException` 등) 발생 또는 중복 요청 무시 처리
   - **구독 취소:**
     - 구독 내역이 존재할 때만 삭제 로직 수행

3. **Controller (`SubscriptionController`)**
   - `@AuthenticationPrincipal` (또는 세션)을 통해 로그인한 사용자(구독자)의 ID 확보
   - `POST /api/subscriptions`: 구독 요청 처리
   - `DELETE /api/subscriptions/{targetId}`: 구독 취소 요청 처리

## ✅ 테스트 결과
- **성공:** 유효한 대상 ID로 구독 요청 시 `200 OK` 및 DB 저장 확인.
   - 구독 중인 대상에 대해 취소 요청 시 `200 OK` 및 DB 삭제 확인.
- **실패:** 존재하지 않는 ID로 구독 시도 시 `404 Not Found` 예외 반환.
   - 이미 구독 중인데 다시 구독 요청 시 `409 Conflict` (또는 비즈니스 예외) 반환.

## 🔗 관련 이슈
- Parent: #29 
- Closes #32 