### PR TITLE
fix : 내 정보 조회(UserInfoResponse) 시 userId 필드 누락 수정

### DIFF
--- a/src/main/java/com/ssook/mvc/dto/user/UserInfoResponse.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserInfoResponse.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class UserInfoResponse {
-    
+
+    private Long userId;
     private String email;
     private String nickname;
     private String intro;
@@ -18,6 +19,7 @@ public class UserInfoResponse {
     // Entity -> DTO 변환 메서드 (편의상 여기에 만듦)
     public static UserInfoResponse from(UserEntity user) {
         return UserInfoResponse.builder()
+                .userId(user.getUserId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .intro(user.getIntro())


### PR DESCRIPTION
## 📌 개요
- 프론트엔드에서 회원 탈퇴 및 정보 수정 기능을 구현하던 중, `GET /users/me` 응답에 사용자 식별자(`userId`)가 포함되지 않아 API 호출이 불가능한 문제를 해결했습니다.

## 👩‍💻 작업 내용
1. **DTO 수정 (`UserInfoResponse.java`)**
   - 클라이언트로 반환되는 응답 객체에 `userId` (Long) 필드를 추가했습니다.
   - 서비스 로직(`UserService`)에서 엔티티의 ID를 DTO에 매핑하도록 수정했습니다.

## 🛠️ 기술적 의사결정
- **필드 노출 필요성:** 보안상 민감한 정보는 아니며, 프론트엔드에서 리소스 접근(삭제/수정) 시 Path Variable로 `userId`를 사용해야 하므로 응답에 포함하는 것이 필수적이라고 판단했습니다.

## ✅ 테스트 결과
- Postman으로 `GET /users/me` 호출 시, `userId` 값이 정상적으로 반환됨을 확인했습니다.

## 🔗 관련 이슈
- (없음 - 긴급 핫픽스)