### PR TITLE
feat : CategoryResponseDto에 parentId 필드 추가

### DIFF
--- a/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
@@ -9,18 +9,20 @@ import lombok.Setter;
 @Builder
 public class CategoryResponseDto {
     private Integer categoryId;
+    private Integer parentId;
     private String name;
     private String imageUrl;
     private String description;
-    
+
     @Setter
-    private Boolean isSubscribed; 
+    private Boolean isSubscribed;
 
     public static CategoryResponseDto from(CategoryEntity entity) {
         return CategoryResponseDto.builder()
                 .categoryId(entity.getCategoryId())
+                .parentId(entity.getParentId())
                 .name(entity.getCategoryName())
-                .imageUrl(entity.getImageUrl()) 
+                .imageUrl(entity.getImageUrl())
                 .description(entity.getDescription())
                 .isSubscribed(false) // 기본값 false (구독 구현 전)
                 .build();


### PR DESCRIPTION
## 📌 개요
- 프론트엔드에서 카테고리를 '상위-하위' 개념으로 그룹화하여 보여주기 위해, 응답 객체(`CategoryResponseDto`)에 계층 구조 정보를 추가했습니다.

## 👩‍💻 작업 내용
1. **DTO 수정 (`CategoryResponseDto.java`)**
   - `parentId` (Integer) 필드 추가.
   - Entity -> DTO 변환 로직에 `parentId` 매핑 코드 추가.

## 🛠️ 기술적 의사결정
- **Flat Data vs Nested Data:** - 백엔드에서 트리 구조로 변환해서 줄 수도 있지만, 데이터 양이 많지 않고 프론트엔드에서 유연하게 그룹핑 로직을 처리하는 것이 낫다고 판단하여, 백엔드는 단순하게 `parentId` 정보만 제공하는 **Flat Data** 방식을 선택했습니다.

## ✅ 테스트 결과
- API 호출 시 `parentId` 값이 정상적으로 포함되어 반환됨을 확인했습니다.

## 🔗 관련 이슈
- Related to #4