### PR TITLE
fix: VideoResponseDto 및 Mapper에 title, videoUrl 필드 추가

### DIFF
--- a/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Data;
 @Data
 public class VideoResponseDto {
     private Long videoId;
+    private String title;
+    private String videoUrl;
     private String thumbnailUrl;
     private Integer viewCount;
 }

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -5,7 +5,8 @@
 <mapper namespace="com.ssook.mvc.repository.VideoMapper">
     <!-- 영상 목록 조회 -->
     <select id="selectVideoList" parameterType="VideoListRequestDto" resultType="VideoResponseDto">
-        SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount
+        SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount,
+        v.title AS title, v.video_url AS videoUrl
         FROM video v
         LEFT JOIN category c ON v.category_id = c.category_id
         WHERE 1=1


### PR DESCRIPTION
## 📌 개요
- 프론트엔드 쇼츠 플레이어 연동 과정에서, `GET /video` 응답에 핵심 데이터인 **제목**과 **영상 URL**이 포함되지 않아 재생이 불가능한 문제를 해결했습니다.

## 👩‍💻 작업 내용
1. **DTO 수정 (`VideoResponseDto.java`)**
   - 클라이언트로 전달할 `title`, `videoUrl` 필드를 추가했습니다.
2. **MyBatis Mapper 수정 (`VideoMapper.xml`)**
   - DB 조회 쿼리(`SELECT`) 절에 해당 컬럼을 추가하여 DTO와 매핑되도록 수정했습니다.

## 🛠️ 기술적 의사결정
- **필드 노출:** 프론트엔드에서 Iframe을 렌더링하기 위해 `videoUrl`이 필수적이며, 오버레이 UI에 제목을 표시하기 위해 `title` 또한 필수 데이터라고 판단하여 추가했습니다.

## ✅ 테스트 결과
- API 호출 시 응답 JSON에 `title`과 `videoUrl`이 정상적으로 포함됨을 확인했습니다.

## 🔗 관련 이슈
- 없음 - 긴급 수정