### PR TITLE
fix : 댓글 수정 시 AI 검사 로직 추가

### DIFF
--- a/src/main/java/com/ssook/mvc/service/CleanBotService.java
+++ b/src/main/java/com/ssook/mvc/service/CleanBotService.java
@@ -33,14 +33,14 @@ public class CleanBotService {
         String url = "https://gms.ssafy.io/gmsapi/api.openai.com/v1/chat/completions";
 
         try {
-            // [Step 1] DTO 객체 생성 (편의 생성자 사용)
+            // DTO 객체 생성 (편의 생성자 사용)
             CleanBotRequest requestDto = new CleanBotRequest(model,
                     "다음 댓글이 욕설, 비하, 혐오 표현을 포함하고 있는지 분석해줘. 유해하면 'BAD', 안전하면 'GOOD'이라고만 답해.\n\n댓글 내용: " + content);
 
-            // [Step 2] DTO -> JSON 문자열 변환 (직렬화)
+            // DTO -> JSON 문자열 변환 (직렬화)
             String jsonBody = objectMapper.writeValueAsString(requestDto);
 
-            // [Step 3] OkHttp 요청 객체 생성
+            // OkHttp 요청 객체 생성
             RequestBody body = RequestBody.create(jsonBody, MediaType.get("application/json; charset=utf-8"));
             Request request = new Request.Builder()
                     .url(url)
@@ -49,14 +49,16 @@ public class CleanBotService {
                     .addHeader("Content-Type", "application/json")
                     .build();
 
-            // [Step 4] 요청 전송 및 응답 처리
+            // 요청 전송 및 응답 처리
             try (Response response = client.newCall(request).execute()) {
                 if (response.isSuccessful() && response.body() != null) {
                     // JSON -> DTO 변환 (역직렬화)
-                    CleanBotResponse responseDto = objectMapper.readValue(response.body().string(), CleanBotResponse.class);
+                    CleanBotResponse responseDto = objectMapper.readValue(response.body().string(),
+                            CleanBotResponse.class);
 
                     // 결과 추출
-                    if (responseDto != null && responseDto.getChoices() != null && !responseDto.getChoices().isEmpty()) {
+                    if (responseDto != null && responseDto.getChoices() != null
+                            && !responseDto.getChoices().isEmpty()) {
                         String result = responseDto.getChoices().get(0).getMessage().getContent();
                         return !"GOOD".equalsIgnoreCase(result != null ? result.trim() : "");
                     }

--- a/src/main/java/com/ssook/mvc/service/CommentService.java
+++ b/src/main/java/com/ssook/mvc/service/CommentService.java
@@ -87,7 +87,7 @@ public class CommentService {
         int totalCount = commentMapper.countParentComments(videoId);
 
         // 부모 댓글이 없을 경우 빈 리스트 반환
-        if(parents.isEmpty())
+        if (parents.isEmpty())
             return new PageResponse<>(Collections.emptyList(), page, size, totalCount);
 
         // 부모 댓글의 Id 추출해서 List로 변환
@@ -103,12 +103,12 @@ public class CommentService {
                 .collect(Collectors.groupingBy(CommentResponseDto::getParentId));
 
         // 부모 댓글에 대댓글 매핑 및 내 댓글인지 확인
-        for(CommentResponseDto parent : parents) {
+        for (CommentResponseDto parent : parents) {
             List<CommentResponseDto> children = replyMap.getOrDefault(parent.getCommentId(), Collections.emptyList());
             parent.setReplies(children);
             checkIsMyComment(parent, userId);
 
-            for(CommentResponseDto child : children)
+            for (CommentResponseDto child : children)
                 checkIsMyComment(child, userId);
         }
 
@@ -128,6 +128,11 @@ public class CommentService {
         // 2. 작성자 본인 확인
         if (!isExistingComment.getUserId().equals(userId)) {
             throw new IllegalArgumentException("본인의 댓글만 수정할 수 있습니다.");
+        }
+
+        // 3. AI 클린봇 검사
+        if (cleanBotService.isSafeComment(commentRequestDto.getContent())) {
+            throw new IllegalArgumentException("AI 클린봇: 욕설이나 부적절한 내용이 감지되었습니다.");
         }
 
         // 3. 댓글 업데이트


### PR DESCRIPTION
## 📌 개요
- AI Clean Bot(댓글 필터링) 기능의 보안 허점을 수정하고, 운영상 문제 해결을 위한 로깅을 강화했습니다.

## 👩‍💻 작업 내용
1. **CleanBotService 로깅 및 안정성 강화**
   - OpenAI API Key 누락이나 API 호출 실패 시, 구체적인 원인을 파악할 수 있도록 에러 로그(`System.err`)를 추가했습니다.
2. **댓글 수정 시 AI 검사 로직 추가 (보안 패치)**
   - 기존 [addComment], [addReply]에만 적용되어 있던 AI 검사를 [modifyComment] 메서드에도 추가했습니다.
   
## 🛠️ 기술적 의사결정
- **수정 API 검사 추가**: 댓글 작성 시점에는 필터링이 되지만, 작성 후 수정 기능을 통해 욕설을 포함시키는 우회 공격이 가능함을 확인하여 수정 로직에도 동일한 검사를 적용했습니다.
- **Fail-Safe 유지 및 가시성 확보**: AI 서비스 장애가 댓글 서비스 전체 장애로 이어지지 않도록 예외 발생 시 '통과'시키는 Fail-Safe 정책은 유지하되, 로그를 상세히 남겨 관리자가 설정을 누락하거나 API 문제를 인지할 수 있도록 개선했습니다.

## ✅ 테스트 결과
- API Key 설정 후 Clean Bot 정상 동작 확인.
- 정상 댓글을 욕설이 포함된 내용으로 수정 시도 시 [IllegalArgumentException] 발생하며 차단됨을 확인.

## 🔗 관련 이슈
- 없음 (긴급 수정)