### PR TITLE
좋아요 카운트 반환 문제 해결

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -21,7 +21,13 @@ public class VideoController {
 
     // 영상 목록 조회
     @GetMapping
-    public ApiResponse<Map<String, Object>> getVideoList(@ModelAttribute VideoListRequestDto videoListRequestDto) {
+    public ApiResponse<Map<String, Object>> getVideoList(@ModelAttribute VideoListRequestDto videoListRequestDto,
+            HttpServletRequest request) {
+        // request에서 userId 꺼내기 (로그인 안했으면 null일 수 있음 -> 필터 확인 필요하나 보통 getAttribute는 null
+        // 가능)
+        Long userId = (Long) request.getAttribute("userId");
+        videoListRequestDto.setUserId(userId);
+
         // 서비스 호출로 영상 목록 가져와서 videos에 할당
         List<VideoResponseDto> videos = videoService.getVideoList(videoListRequestDto);
         // Map에 videos넣기

--- a/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
@@ -45,4 +45,6 @@ public class VideoListRequestDto {
     public void setSize(int size) {
         this.size = size;
     }
+
+    private Long userId; // 내 좋아요 여부 확인용
 }

--- a/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/response/VideoResponseDto.java
@@ -10,4 +10,6 @@ public class VideoResponseDto {
     private String thumbnailUrl;
     private Integer viewCount;
     private Integer commentCount;
+    private boolean liked;
+    private Integer likeCount;
 }

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -7,9 +7,12 @@
     <select id="selectVideoList" parameterType="VideoListRequestDto" resultType="VideoResponseDto">
         SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount,
         v.title AS title, v.video_url AS videoUrl,
-        (SELECT COUNT(*) FROM comment cm WHERE cm.video_id = v.video_id AND cm.is_deleted = false) AS commentCount
+        (SELECT COUNT(*) FROM comment cm WHERE cm.video_id = v.video_id AND cm.is_deleted = false) AS commentCount,
+        (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) AS likeCount,
+        (my_reaction.reaction_id IS NOT NULL) AS liked
         FROM video v
         LEFT JOIN category c ON v.category_id = c.category_id
+        LEFT JOIN reaction my_reaction ON v.video_id = my_reaction.video_id AND my_reaction.user_id = #{userId}
         WHERE 1=1
 
         <if test="categoryName != null and categoryName != ''">


### PR DESCRIPTION
## 📌 개요
- 영상 목록 조회(Feed) 시, 각 영상의 좋아요 수와 사용자의 좋아요 여부를 함께 반환하도록 개선했습니다.
- 좋아요 상태 조회 시 발생하는 부정확한 데이터 문제(False Positive)를 해결했습니다.

## 👩‍💻 작업 내용
1. **DTO 수정**
   - [VideoResponseDto] : `liked`(좋아요 여부), `likeCount`(총 개수) 필드 추가.
   - [VideoListRequestDto] : 로그인한 사용자의 반응 확인을 위한 `userId` 필드 추가.
2. **Mapper 쿼리 최적화**
   - [VideoMapper.xml] : 영상 목록 조회 시 `reaction` 테이블을 조인하여 좋아요 정보를 한 번에 가져오도록 수정.
   - 트러블 슈팅: `EXISTS` 서브쿼리 사용 시 발생하던 데이터 오류를 `LEFT JOIN` 방식으로 변경하여 해결.
3. **Controller**
   - [VideoController] : `HttpServletRequest`에서 `userId`를 추출하여 DTO에 주입하는 로직 추가.

## 🛠️ 기술적 의사결정
- **MyBatis JOIN 최적화**: N+1 문제를 방지하고, 피드 로딩 시 추가적인 API 호출 없이 하트 상태를 보여주기 위해 목록 조회 쿼리에 좋아요 관련 서브쿼리와 조인을 포함시켰습니다.
- **Data Integrity**: 단순히 `EXISTS`를 사용할 경우 파라미터 바인딩 문제로 타인의 좋아요를 내 것으로 착각하는 문제가 있어, `LEFT JOIN ... AND user_id = ?` 구문으로 변경하여 데이터 정확성을 보장했습니다.

## ✅ 테스트 결과
- 영상 피드 조회 시 `likeCount`와 `liked` 필드가 정상적으로 반환됨.
- 내가 좋아요를 누르지 않은 영상은 `liked: false`, 누른 영상은 `liked: true`로 정확히 구분됨을 확인.

## 🔗 관련 이슈
- 없음