### PR TITLE
Fix : 프로필 이미지 정적 리소스 접근 허용

### DIFF
--- a/src/main/java/com/ssook/mvc/config/WebConfig.java
+++ b/src/main/java/com/ssook/mvc/config/WebConfig.java
@@ -17,11 +17,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/**") // 1. 기본적으로 모든 URL을 막음
-                .excludePathPatterns(   // 2. 아래 URL들은 검사 제외 (화이트리스트)
-                        "/users/signup",  // 회원가입
-                        "/users/login",   // 로그인
+                .excludePathPatterns( // 2. 아래 URL들은 검사 제외 (화이트리스트)
+                        "/users/signup", // 회원가입
+                        "/users/login", // 로그인
                         "/swagger-ui/**", // 스웨거 (문서)
-                        "/v3/api-docs/**" // 스웨거 (문서)
+                        "/v3/api-docs/**", // 스웨거 (문서)
+                        "/images/**" // 프로필 이미지
                 );
     }
 }


### PR DESCRIPTION
## 📌 개요
- 프로필 이미지 등 정적 리소스에 대한 접근 권한 설정 수정

## 👩‍💻 작업 내용
1. **WebConfig 수정**: 인터셉터 제외 경로(`excludePathPatterns`)에 `/images/**` 추가

## 🛠️ 기술적 의사결정
- **접근성 제외**: 프로필 이미지는 로그인 전이나 토큰 만료 등 인증 상태와 무관하게 보여져야 하는 공개 리소스이므로 JWT 인증 필터에서 제외했습니다.

## ✅ 테스트 결과
- 로그인하지 않은 상태(토큰 없음)에서도 브라우저 주소창을 통해 이미지 URL 접근 성공

## 🔗 관련 이슈
- #