### PR TITLE
fix : 카테고리 상세 조회 매핑 오류 수정

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/CategoryController.java
+++ b/src/main/java/com/ssook/mvc/controller/CategoryController.java
@@ -24,27 +24,31 @@ public class CategoryController {
     @GetMapping
     public ApiResponse<PageResponse<CategoryResponseDto>> getCategoryList(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int perPage, 
+            @RequestParam(defaultValue = "10") int perPage,
+            @RequestParam(required = false) String keyword,
             HttpServletRequest request) {
-        
+
         // 인터셉터가 넣어준 userId 꺼내기 (비로그인 시 null일 수 있음)
         Long userId = (Long) request.getAttribute("userId");
-        
-        PageResponse<CategoryResponseDto> response = categoryService.getCategoryList(page, perPage, userId);
-        
+
+        PageResponse<CategoryResponseDto> response = categoryService.getCategoryList(page, perPage, userId, keyword);
+
         return ApiResponse.success(response);
     }
-    
+
     @GetMapping("/{categoryId}")
-    public ApiResponse<CategoryResponseDto> getCategoryDetail(
+    public ApiResponse<Object> getCategoryDetail(
             @PathVariable Integer categoryId,
             HttpServletRequest request) {
-        
-        // 상세 조회에서도 '내가 구독했는지' 보여줘야 하므로 userId를 꺼냅니다.
-        Long userId = (Long) request.getAttribute("userId");
-        
-        CategoryResponseDto response = categoryService.getCategoryDetail(categoryId, userId);
-        
-        return ApiResponse.success(response);
+
+        try {
+            Long userId = (Long) request.getAttribute("userId");
+            CategoryResponseDto response = categoryService.getCategoryDetail(categoryId, userId);
+
+            return ApiResponse.success(response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ApiResponse<>(500, e.toString(), null);
+        }
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/category/response/CategoryResponseDto.java
@@ -13,6 +13,10 @@ public class CategoryResponseDto {
     private String name;
     private String imageUrl;
     private String description;
+    private Boolean hasChildren;
+
+    @Setter
+    private java.util.List<CategoryResponseDto> children;
 
     @Setter
     private Boolean isSubscribed;
@@ -24,6 +28,7 @@ public class CategoryResponseDto {
                 .name(entity.getCategoryName())
                 .imageUrl(entity.getImageUrl())
                 .description(entity.getDescription())
+                .hasChildren(entity.isHasChildren())
                 .isSubscribed(false) // 기본값 false (구독 구현 전)
                 .build();
     }

--- a/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class VideoListRequestDto {
     private String categoryName; // 카테고리 명
+    private Integer categoryId; // 카테고리 ID
     private Integer sortedType; // 정렬기준(1: 최신순, 2: 조회수순)
     private int page = 1; // 페이지 번호
     private int size = 12; // 페이지당 개수

--- a/src/main/java/com/ssook/mvc/entity/CategoryEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/CategoryEntity.java
@@ -3,13 +3,15 @@ package com.ssook.mvc.entity;
 import lombok.*;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CategoryEntity extends BaseEntity {
-    private Integer categoryId;    // DB: INT
-    private Integer parentId;      // DB: INT (상위 카테고리)
-    private String categoryName;   // DB: VARCHAR
-    private String description;    // DB: VARCHAR
-    private String imageUrl;       // DB: VARCHAR
+    private Integer categoryId; // DB: INT
+    private Integer parentId; // DB: INT (상위 카테고리)
+    private String categoryName; // DB: VARCHAR
+    private String description; // DB: VARCHAR
+    private String imageUrl; // DB: VARCHAR
+    private boolean hasChildren; // DB: Calculated (Subquery)
 }

--- a/src/main/java/com/ssook/mvc/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/ssook/mvc/interceptor/JwtInterceptor.java
@@ -15,7 +15,8 @@ public class JwtInterceptor implements HandlerInterceptor {
     private final JwtUtil jwtUtil;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
         // 1. 요청의 Method가 'OPTIONS'인 경우 통과 (CORS 예비 요청 처리)
         // Vue.js가 "나 요청 보내도 돼?" 하고 찔러보는 건데 막으면 안 됨
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
@@ -31,8 +32,18 @@ public class JwtInterceptor implements HandlerInterceptor {
             // 이제 Controller에서는 request.getAttribute("userId")로 바로 꺼내 쓸 수 있음!
             Long userId = jwtUtil.getUserId(token);
             request.setAttribute("userId", userId);
-            
+
             return true; // 통과! (Controller로 이동)
+        }
+
+        // [추가] 토큰이 없거나 유효하지 않더라도, "조회(GET)" 기능 중 일부는 허용 (비로그인/게스트 모드)
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        // /category/** 또는 /video/** 의 GET 요청은 비로그인 허용
+        if ("GET".equalsIgnoreCase(method) &&
+                (requestURI.startsWith("/category") || requestURI.startsWith("/video"))) {
+            return true; // userId 없이 통과
         }
 
         // 4. 토큰이 없거나 가짜면 에러 응답 (401 Unauthorized)

--- a/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/CategoryMapper.java
@@ -8,11 +8,15 @@ import java.util.List;
 @Mapper
 public interface CategoryMapper {
     // 목록 조회 (페이징 적용)
-    List<CategoryEntity> selectCategoryList(@Param("offset") int offset, @Param("limit") int limit);
+    List<CategoryEntity> selectCategoryList(@Param("offset") int offset, @Param("limit") int limit,
+            @Param("keyword") String keyword);
 
     // 전체 개수 (페이징 계산용)
-    int countCategory();
-    
+    int countCategory(@Param("keyword") String keyword);
+
     // 상세 조회
-    CategoryEntity selectCategoryById(Integer categoryId);
+    CategoryEntity selectCategoryById(@Param("categoryId") Integer categoryId);
+
+    // 자식 카테고리 조회
+    List<CategoryEntity> selectCategoryChildren(@Param("parentId") Integer parentId);
 }

--- a/src/main/java/com/ssook/mvc/repository/SubscriptionMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/SubscriptionMapper.java
@@ -18,5 +18,5 @@ public interface SubscriptionMapper {
     boolean existsSubscription(@Param("userId") Long userId, @Param("categoryId") Integer categoryId);
 
     // 내가 구독한 카테고리 ID 목록 조회 (CategoryService에서 사용 예정)
-    List<Integer> selectSubscribedCategoryIds(Long userId);
+    List<Integer> selectSubscribedCategoryIds(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ssook/mvc/service/CategoryService.java
+++ b/src/main/java/com/ssook/mvc/service/CategoryService.java
@@ -24,13 +24,13 @@ public class CategoryService {
     private final SubscriptionMapper subscriptionMapper;
 
     @Transactional(readOnly = true)
-    public PageResponse<CategoryResponseDto> getCategoryList(int page, int size, Long userId) {
+    public PageResponse<CategoryResponseDto> getCategoryList(int page, int size, Long userId, String keyword) {
         // 페이징 계산 (offset = (페이지-1) * 개수)
         int offset = (page - 1) * size;
 
         // DB 조회
-        List<CategoryEntity> entities = categoryMapper.selectCategoryList(offset, size);
-        int totalCount = categoryMapper.countCategory();
+        List<CategoryEntity> entities = categoryMapper.selectCategoryList(offset, size, keyword);
+        int totalCount = categoryMapper.countCategory(keyword);
 
         // Entity -> DTO 변환
         List<CategoryResponseDto> content = entities.stream()
@@ -41,10 +41,10 @@ public class CategoryService {
         if (userId != null && !content.isEmpty()) {
             // 내가 구독한 카테고리 ID 목록을 가져옴 (예: [1, 3, 5])
             List<Integer> subscribedIds = subscriptionMapper.selectSubscribedCategoryIds(userId);
-            
+
             // 비교하기 쉽게 Set으로 변환 (검색 속도 O(1))
             // import java.util.Set; import java.util.HashSet;
-            Set<Integer> subscribedSet = new HashSet<>(subscribedIds); 
+            Set<Integer> subscribedSet = new HashSet<>(subscribedIds);
 
             // 리스트를 돌면서 ID가 Set에 있으면 isSubscribed = true
             for (CategoryResponseDto dto : content) {
@@ -57,7 +57,7 @@ public class CategoryService {
         // 공통 페이징 객체에 담아 반환
         return new PageResponse<>(content, page, size, totalCount);
     }
-    
+
     // 카테고리 상세 조회
     @Transactional(readOnly = true)
     public CategoryResponseDto getCategoryDetail(Integer categoryId, Long userId) {
@@ -72,10 +72,32 @@ public class CategoryService {
         // DTO 변환
         CategoryResponseDto dto = CategoryResponseDto.from(category);
 
+        // 자식 카테고리가 있는 경우 조회 및 설정
+        if (category.isHasChildren()) {
+            List<CategoryEntity> children = categoryMapper.selectCategoryChildren(categoryId);
+            List<CategoryResponseDto> childrenDto = children.stream()
+                    .map(CategoryResponseDto::from)
+                    .collect(Collectors.toList());
+            dto.setChildren(childrenDto);
+        }
+
         // 상세 조회 시 구독 여부 체크
         if (userId != null) {
             boolean isSubscribed = subscriptionMapper.existsSubscription(userId, categoryId);
             dto.setIsSubscribed(isSubscribed);
+
+            // 자식들도 구독 여부 체크
+            if (dto.getChildren() != null) {
+                // 내 구독 목록
+                List<Integer> subscribedIds = subscriptionMapper.selectSubscribedCategoryIds(userId);
+                Set<Integer> subscribedSet = new HashSet<>(subscribedIds);
+
+                for (CategoryResponseDto child : dto.getChildren()) {
+                    if (subscribedSet.contains(child.getCategoryId())) {
+                        child.setIsSubscribed(true);
+                    }
+                }
+            }
         }
 
         return dto;

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -5,18 +5,38 @@
 <mapper namespace="com.ssook.mvc.repository.CategoryMapper">
     
     <select id="selectCategoryList" resultType="com.ssook.mvc.entity.CategoryEntity">
-        SELECT * FROM category
-        ORDER BY category_id ASC
+        SELECT c.*, 
+        (SELECT COUNT(*) FROM category child WHERE child.parent_id = c.category_id) > 0 AS hasChildren
+        FROM category c
+        WHERE 1=1
+        <if test="keyword != null and keyword != ''">
+            AND (c.category_name LIKE CONCAT('%', #{keyword}, '%') OR c.description LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY c.category_id ASC
         LIMIT #{limit} OFFSET #{offset}
     </select>
 
     <select id="countCategory" resultType="int">
         SELECT COUNT(*) FROM category
+        WHERE 1=1
+        <if test="keyword != null and keyword != ''">
+            AND (category_name LIKE CONCAT('%', #{keyword}, '%') OR description LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
     </select>
     
-    <select id="selectCategoryById" parameterType="int" resultType="com.ssook.mvc.entity.CategoryEntity">
-    SELECT * FROM category 
-    WHERE category_id = #{categoryId}
-</select>
+    <select id="selectCategoryById" resultType="com.ssook.mvc.entity.CategoryEntity">
+        SELECT c.*, 
+        (SELECT COUNT(*) FROM category child WHERE child.parent_id = c.category_id) > 0 AS hasChildren
+        FROM category c 
+        WHERE c.category_id = #{categoryId}
+    </select>
+
+    <select id="selectCategoryChildren" resultType="com.ssook.mvc.entity.CategoryEntity">
+        SELECT c.*, 
+        (SELECT COUNT(*) FROM category child WHERE child.parent_id = c.category_id) > 0 AS hasChildren
+        FROM category c
+        WHERE c.parent_id = #{parentId}
+        ORDER BY c.category_id ASC
+    </select>
     
 </mapper>

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -18,6 +18,9 @@
         <if test="categoryName != null and categoryName != ''">
             AND c.category_name = #{categoryName}
         </if>
+        <if test="categoryId != null">
+            AND v.category_id = #{categoryId}
+        </if>
 
         ORDER BY
         <choose>


### PR DESCRIPTION
## 📌 개요
- 카테고리 상세 조회 시 `500 Error`를 유발하던 데이터 매핑 오류를 수정하고, UX 개선을 위해 비로그인 유저의 조회 권한을 허용했습니다.

## 👩‍💻 작업 내용
1. **Mapper fix**: [CategoryMapper] 및 [SubscriptionMapper]에 명시적 `@Param` 어노테이션을 추가하여 파라미터 바인딩 실패 문제를 해결했습니다.
2. **Logic update**: [CategoryMapper.xml]에 자식 카테고리 존재 여부(`hasChildren`)를 판단하는 서브쿼리를 추가했습니다.
3. **Security**: [JwtInterceptor]에서 GET 방식의 카테고리/영상 조회 요청은 토큰 검증을 통과(Skip)하도록 예외 로직을 추가했습니다.

## ✅ 테스트 결과
- 비로그인 상태(토큰 없음)에서 상세 API 호출 시 401 에러 없이 정상 응답(200) 확인.
- 상세 조회 시 에러 없이 데이터 반환 확인.