### PR TITLE
feat: Video - 내가 좋아요한 영상만 가져오는 기능 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -48,4 +48,27 @@ public class VideoController {
 
         return ApiResponse.success(videoDetail);
     }
+
+    // 내가 좋아요한 영상 모아보기
+    @GetMapping("/my-likes")
+    public ApiResponse<Map<String, Object>> getMyLikedVideos(
+            @ModelAttribute VideoListRequestDto requestDto,
+            HttpServletRequest request
+    ) {
+        // 1. Interceptor에서 검증 후 넣어준 userId 꺼내기
+        Long userId = (Long) request.getAttribute("userId");
+
+        // 2. DTO 설정
+        requestDto.setUserId(userId);       // 영상마다 내가 좋아요 눌렀는지 확인용
+        requestDto.setLikedUserId(userId);  // 이 유저가 좋아요한 영상만 필터링해서 가져옴
+
+        // 3. Service 호출 (기존 목록 조회 로직 재사용)
+        List<VideoResponseDto> likedVideos = videoService.getVideoList(requestDto);
+
+        // 4. 응답 포맷 통일 (기존 getVideoList와 동일하게 "videos" 키에 담아서 리턴)
+        Map<String, Object> data = new HashMap<>();
+        data.put("videos", likedVideos);
+
+        return ApiResponse.success(data);
+    }
 }

--- a/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
@@ -15,37 +15,6 @@ public class VideoListRequestDto {
         return (page - 1) * size;
     }
 
-    public String getCategoryName() {
-        return categoryName;
-    }
-
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
-
-    public Integer getSortedType() {
-        return sortedType;
-    }
-
-    public void setSortedType(Integer sortedType) {
-        this.sortedType = sortedType;
-    }
-
-    public int getPage() {
-        return page;
-    }
-
-    public void setPage(int page) {
-        this.page = page;
-    }
-
-    public int getSize() {
-        return size;
-    }
-
-    public void setSize(int size) {
-        this.size = size;
-    }
-
     private Long userId; // 내 좋아요 여부 확인용
+    private Long likedUserId; // 해당 유저가 좋아요한 영상만 가져오기 위함
 }

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -13,6 +13,13 @@
         FROM video v
         LEFT JOIN category c ON v.category_id = c.category_id
         LEFT JOIN reaction my_reaction ON v.video_id = my_reaction.video_id AND my_reaction.user_id = #{userId}
+
+        <if test="likedUserId != null">
+            INNER JOIN reaction r_filter
+            ON v.video_id = r_filter.video_id
+            AND r_filter.user_id = #{likedUserId}
+        </if>
+
         WHERE 1=1
 
         <if test="categoryName != null and categoryName != ''">
@@ -26,6 +33,9 @@
         <choose>
             <when test="sortedType == 2">
                 v.view_count DESC, v.created_at DESC
+            </when>
+            <when test="likedUserId != null">
+                r_filter.created_at DESC
             </when>
             <otherwise>
                 v.created_at DESC


### PR DESCRIPTION
## 📌 개요
- 내가 좋아요한 기능만 가져오는 기능 추가

## 👩‍💻 작업 내용
1. '내가 좋아요한 영상 모아보기' 기능 구현 (GET /video/my-likes 엔드포인트 추가)

## 🛠️ 기술적 의사결정
1. MyBatis 동적 쿼리를 활용한 조회 로직 재사용
    - '좋아요한 영상 목록'을 조회하기 위해 별도의 Service 메서드나 Mapper 쿼리를 새로 만드는 대신, 기존의 영상 목록 조회(getVideoList) 로직을 재사용
    - DTO에 likedUserId 필드를 추가하고, Mapper XML에서 <if> 태그를 사용하여 해당 필드가 있을 때만 reaction 테이블과 INNER JOIN 하도록 구현. 이를 통해 페이징(Paging) 및 정렬(Sorting) 로직의 중복을 제거하고 유지보수성을 높임

## ✅ 테스트 결과
- http://localhost:8080/video/my-likes
<img width="838" height="1227" alt="스크린샷 2025-12-22 173609" src="https://github.com/user-attachments/assets/f899c044-55e4-41ec-8b81-28eeeb966d46" />


## 🔗 관련 이슈
- #55 