### PR TITLE
feat : 영상 검색 구독 필터링 API 확장

### DIFF
--- a/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
+++ b/src/main/java/com/ssook/mvc/dto/video/request/VideoListRequestDto.java
@@ -17,4 +17,8 @@ public class VideoListRequestDto {
 
     private Long userId; // 내 좋아요 여부 확인용
     private Long likedUserId; // 해당 유저가 좋아요한 영상만 가져오기 위함
+
+    private String keyword; // 검색어 (영상 제목)
+
+    private Boolean onlySubscribed; // 구독한 카테고리 영상만 보기
 }

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -19,6 +19,12 @@
             ON v.video_id = r_filter.video_id
             AND r_filter.user_id = #{likedUserId}
         </if>
+        
+        <if test="onlySubscribed == true and userId != null">
+            INNER JOIN subscription sub
+            ON v.category_id = sub.category_id
+            AND sub.user_id = #{userId}
+        </if>
 
         WHERE 1=1
 
@@ -28,11 +34,17 @@
         <if test="categoryId != null">
             AND v.category_id = #{categoryId}
         </if>
+        <if test="keyword != null and keyword != ''">
+            AND v.title LIKE CONCAT('%', #{keyword}, '%')
+        </if>
 
         ORDER BY
         <choose>
             <when test="sortedType == 2">
                 v.view_count DESC, v.created_at DESC
+            </when>
+            <when test="sortedType == 3">
+                (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) DESC, v.created_at DESC
             </when>
             <when test="likedUserId != null">
                 r_filter.created_at DESC


### PR DESCRIPTION
## 📌 개요
- 프론트엔드 검색/구독 기능을 위한 영상 조회 API 확장
## 👩‍💻 작업 내용
### 🔍 영상 검색 API 확장
- **VideoListRequestDto**: 
  - 검색어 수신을 위한 `keyword` 필드 추가
  - 구독 필터링을 위한 `onlySubscribed` 필드 추가
- **VideoMapper.xml**: 
  - `LIKE` 검색 쿼리 추가 (`title` 기준 부분 일치 검색)
  - `onlySubscribed=true` 시 사용자가 구독한 카테고리만 필터링 (`JOIN subscription`)
  - `sortedType=3` (좋아요순) 정렬 로직 추가 (Reaction 테이블 서브쿼리)
- **VideoController**: 기존 목록 조회 API 재활용하여 검색 및 필터 기능 통합 제공
### 🧪 테스트
- [x] 키워드 검색 API 호출 및 결과 확인
- [x] 구독 필터 적용 시 구독한 카테고리 영상만 반환되는지 확인
- [x] 좋아요순 정렬 확인