### PR TITLE
fix : AI퀴즈 정답 검증 로직 강화

### DIFF
--- a/src/main/java/com/ssook/mvc/dto/ai/response/QuizResponseDto.java
+++ b/src/main/java/com/ssook/mvc/dto/ai/response/QuizResponseDto.java
@@ -6,8 +6,9 @@ import java.util.List;
 
 @Data
 public class QuizResponseDto {
-    private String question;       // 문제 내용
-    private List<String> options;  // 보기 (4개)
-    private int answer;            // 정답 번호
-    private String explanation;    // 해설 (선택 사항)
+    private String question; // 문제 내용
+    private List<String> options; // 보기 (4개)
+    private int answer; // 정답 번호
+    private String answerText; // 정답 텍스트 (검증용)
+    private String explanation; // 해설 (선택 사항)
 }

--- a/src/main/java/com/ssook/mvc/service/AiService.java
+++ b/src/main/java/com/ssook/mvc/service/AiService.java
@@ -63,7 +63,8 @@ public class AiService {
                         return responseDto.getChoices().get(0).getMessage().getContent();
                     }
                 } else {
-                    log.error("AI 요청 실패: code={}, body={}", response.code(), response.body() != null ? response.body().string() : "null");
+                    log.error("AI 요청 실패: code={}, body={}", response.code(),
+                            response.body() != null ? response.body().string() : "null");
                 }
             }
         } catch (IOException e) {
@@ -79,11 +80,11 @@ public class AiService {
     public List<QuizResponseDto> generateQuiz(String keyword) {
         String prompt = String.format(
                 "주제 '%s'에 대한 초보자 수준의 객관식 퀴즈 3개를 만들어줘. " +
+                        "정답(answer)은 0~3 사이의 인덱스여야 히고, answerText는 그 인덱스에 해당하는 보기를 그대로 적어. " +
                         "반드시 아래 JSON 포맷을 지켜서 배열로 반환해. 다른 말은 하지 마. " +
                         "JSON 예시: " +
-                        "[{\"question\":\"문제내용\", \"options\":[\"보기1\",\"보기2\",\"보기3\",\"보기4\"], \"answerIndex\":0, \"explanation\":\"해설\"}]",
-                keyword
-        );
+                        "[{\"question\":\"문제내용\", \"options\":[\"보기1\",\"보기2\",\"보기3\",\"보기4\"], \"answer\":2, \"answerText\":\"보기3\", \"explanation\":\"해설\"}]",
+                keyword);
 
         String content = callOpenAiApi(prompt);
 
@@ -95,7 +96,27 @@ public class AiService {
 
                 if (firstIndex != -1 && lastIndex != -1) {
                     content = content.substring(firstIndex, lastIndex + 1);
-                    return objectMapper.readValue(content, new TypeReference<>() {});
+                    List<QuizResponseDto> quizzes = objectMapper.readValue(content, new TypeReference<>() {
+                    });
+
+                    // 검증 로직: answerText를 기반으로 answer 인덱스 재설정
+                    for (QuizResponseDto quiz : quizzes) {
+                        if (quiz.getAnswerText() != null && quiz.getOptions() != null) {
+                            int correctIdx = -1;
+                            for (int i = 0; i < quiz.getOptions().size(); i++) {
+                                // 텍스트 비교 (공백 제거 후)
+                                if (quiz.getOptions().get(i).trim().equalsIgnoreCase(quiz.getAnswerText().trim())) {
+                                    correctIdx = i;
+                                    break;
+                                }
+                            }
+                            // 텍스트가 일치하는 보기가 있으면 그 인덱스로 덮어씌움
+                            if (correctIdx != -1) {
+                                quiz.setAnswer(correctIdx);
+                            }
+                        }
+                    }
+                    return quizzes;
                 } else {
                     log.warn("AI 응답에서 JSON 배열을 찾을 수 없습니다: {}", content);
                 }


### PR DESCRIPTION
## 📌 개요
- OpenAI API를 활용한 **실시간 퀴즈 생성 서비스**를 구축하고, AI 응답의 정확성을 보장하는 **검증 로직**을 추가했습니다.
## 👩‍💻 작업 내용
1. **AI 서비스 구현 ([AiService.java]**
   - `OpenAI Chat Completion API` 연동.
   - **프롬프트 엔지니어링**: 사용자가 입력한 키워드를 기반으로 객관식 3문제를 JSON 배열로 반환하도록 구조화된 프롬프트 설계.
2. **정답 검증 로직 강화 (Self-Correction)**
   - **문제**: AI가 가끔 정답 인덱스(`answer`)와 실제 정답 내용이 불일치하는(Hallucination) 현상 발견.
   - **해결**:
     - 프롬프트에 `answerText`(정답 텍스트) 필드를 추가 요청.
     - 파싱 단계에서 `answerText`와 `options` 리스트를 텍스트 비교하여 인덱스를 **재계산(Correction)**하는 로직 추가. 이로써 AI가 번호를 틀려도 텍스트가 맞으면 무조건 정답 로직이 보장됨.
3. **API 엔드포인트**
   - `POST /ai/quiz`: 키워드를 받아 퀴즈 리스트 반환.
## 🛠️ 기술적 의사결정
- **Robust Parsing (강건한 파싱)**: LLM의 응답은 비정형일 수 있으므로, 결과 문자열에서 `[`와 `]` 사이의 JSON 부분만 추출하여 파싱하도록 구현하여, 앞뒤에 불필요한 사족이 붙어도 에러가 나지 않도록 처리했습니다.
- **Content-Based Validation**: AI의 '논리적 판단(정답 고르기)'과 '기계적 출력(인덱스 번호)' 간의 불일치를 해결하기 위해, 가장 신뢰할 수 있는 '생성된 보기 내용'을 기준으로 정답을 역산출하는 방어적 프로그래밍을 적용했습니다.
## ✅ 테스트 결과
- **정상 생성**: "Spring Framework" 키워드로 요청 시 3개의 객관식 문제 JSON 반환 확인.
- **검증 로직**: AI가 잘못된 인덱스를 반환하는 케이스(Mock 테스트)에서도 `answerText`를 통해 올바른 인덱스로 수정되어 클라이언트에 전달됨을 검증.
## 🔗 관련 이슈
- #