### PR TITLE
feat: 사용자 통계 API 확장 (Level, WatchTime, TimeTag)

### DIFF
--- a/src/main/java/com/ssook/mvc/service/VideoService.java
+++ b/src/main/java/com/ssook/mvc/service/VideoService.java
@@ -49,6 +49,7 @@ public class VideoService {
                     ));
                 } catch (Exception e) {
                     // 중복 시청 등 에러 무시 (혹은 로거)
+                    System.err.println("[VideoService] Failed to insert view history: " + e.getMessage());
                 }
             }
         }
@@ -79,25 +80,43 @@ public class VideoService {
 
             // 데이터가 정렬되어 있다고 가정 (ORDER BY created_at DESC)
             for (java.util.Map<String, Object> log : history) {
-                java.sql.Date sqlDate = (java.sql.Date) log.get("viewDate");
-                java.time.LocalDate viewDate = sqlDate.toLocalDate();
+                try {
+                    Object dateObj = log.get("viewDate");
+                    // MyBatis Map keys might be case-sensitive depending on config (try upper case
+                    // if null)
+                    if (dateObj == null)
+                        dateObj = log.get("VIEWDATE");
 
-                if (lastDate == null) {
-                    // 첫 기록이 오늘 또는 어제여야 스트릭 유지
-                    if (viewDate.equals(today) || viewDate.equals(today.minusDays(1))) {
-                        streak = 1;
-                        lastDate = viewDate;
+                    if (dateObj == null)
+                        continue; // Skip if date is missing
+
+                    java.time.LocalDate viewDate;
+                    if (dateObj instanceof java.sql.Date) {
+                        viewDate = ((java.sql.Date) dateObj).toLocalDate();
                     } else {
-                        break; // 스트릭 끊김
+                        // Handle strict date or string parsing
+                        viewDate = java.sql.Date.valueOf(dateObj.toString()).toLocalDate();
                     }
-                } else {
-                    if (viewDate.equals(lastDate.minusDays(1))) {
-                        streak++;
-                        lastDate = viewDate;
-                    } else if (viewDate.isBefore(lastDate.minusDays(1))) {
-                        break;
+
+                    if (lastDate == null) {
+                        // 첫 기록이 오늘 또는 어제여야 스트릭 유지
+                        if (viewDate.equals(today) || viewDate.equals(today.minusDays(1))) {
+                            streak = 1;
+                            lastDate = viewDate;
+                        } else {
+                            break; // 스트릭 끊김
+                        }
+                    } else {
+                        if (viewDate.equals(lastDate.minusDays(1))) {
+                            streak++;
+                            lastDate = viewDate;
+                        } else if (viewDate.isBefore(lastDate.minusDays(1))) {
+                            break;
+                        }
+                        // 같은 날짜면 패스
                     }
-                    // 같은 날짜면 패스
+                } catch (Exception e) {
+                    System.err.println("[VideoService] Error calculating streak: " + e.getMessage());
                 }
             }
         }
@@ -111,7 +130,18 @@ public class VideoService {
         // 0~5: 새벽, 6~11: 오전, 12~17: 오후, 18~23: 저녁
         int[] timeSlots = new int[4]; // 0, 1, 2, 3
         for (java.util.Map<String, Object> log : history) {
-            int hour = (int) log.get("viewHour");
+            Object hourObj = log.get("viewHour");
+            if (hourObj == null)
+                hourObj = log.get("VIEWHOUR");
+
+            if (hourObj == null)
+                continue;
+
+            int hour = 0;
+            if (hourObj instanceof Number) {
+                hour = ((Number) hourObj).intValue();
+            }
+
             if (hour >= 0 && hour < 6)
                 timeSlots[0]++;
             else if (hour >= 6 && hour < 12)

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -63,7 +63,8 @@
         (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) AS likeCount,
         (SELECT COUNT(*) FROM comment c WHERE c.video_id = v.video_id AND c.is_deleted = false) AS commentCount,
         EXISTS(SELECT 1 FROM reaction r WHERE r.video_id = v.video_id AND r.user_id = #{userId}) AS liked,
-        EXISTS(SELECT 1 FROM subscription s WHERE s.category_id = v.category_id AND s.user_id = #{userId}) AS subscribed
+        EXISTS(SELECT 1 FROM subscription s WHERE s.category_id = v.category_id AND s.user_id = #{userId}) AS subscribed,
+        v.category_id AS categoryId
 
         FROM video v
         WHERE v.video_id = #{videoId}


### PR DESCRIPTION
## 📌 개요
- 마이페이지 '내 통계' 대시보드 기능을 위해 사용자 통계 조회 API[getUserStats]를 확장했습니다.

## 👩‍💻 작업 내용
1. **시청 데이터 분석 로직 추가 [VideoService]**
   - `video_view_history` 테이블의 로그를 분석하여 주 시청 시간대(`TimeTag`)를 도출하는 로직 구현.
   - 총 시청 횟수 기반 **레벨(Level)** 및 **총 시청 시간(WatchTime)** 계산 로직 추가.
2. **DTO 확장**
   - [UserStatsResponseDto]에 `level`, `watchTime`, `streak`, `timeTag`, `topCategory` 필드 추가.
3. **쿼리 최적화**
   - 사용자가 가장 많이 본 카테고리(`topCategory`)를 효율적으로 조회하도록 `VideoMapper` 쿼리 수정.

## 🛠️ 기술적 의사결정
- **Time Tag 알고리즘**: 복잡한 시계열 분석 대신, 하루를 4개의 구간(새벽, 오전, 오후, 저녁)으로 나누고 가장 빈도가 높은 구간을 태그로 선정하도록 단순화하여 조회 성능을 확보했습니다.
- **레벨 시스템**: 현재는 시청 횟수에 비례하는 간단한 임계값(Threshold) 방식을 적용했으나, 향후 경험치(XP) 테이블로 확장 가능한 구조로 DTO를 설계했습니다.

## ✅ 테스트 결과
- Postman을 사용하여 다양한 시청 기록을 가진 유저 시나리오에 대해 예상된 통계 값(레벨, 시간대 태그 등)이 반환되는지 검증 완료했습니다.

## 🔗 관련 이슈
- #