### PR TITLE
feat : 실시간 인기 쇼츠 및 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/ssook/mvc/controller/UserController.java
+++ b/src/main/java/com/ssook/mvc/controller/UserController.java
@@ -130,4 +130,16 @@ public class UserController {
         UserStatsResponseDto stats = videoService.getUserStats(userId);
         return ApiResponse.success(stats);
     }
+
+    // 비밀번호 변경 API
+    @PatchMapping("/me/password")
+    public ApiResponse<Object> changePassword(
+            @Valid @RequestBody com.ssook.mvc.dto.user.UserPasswordChangeRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        userService.changePassword(userId, request);
+
+        return ApiResponse.createSuccess("비밀번호가 성공적으로 변경되었습니다.");
+    }
 }

--- a/src/main/java/com/ssook/mvc/controller/VideoController.java
+++ b/src/main/java/com/ssook/mvc/controller/VideoController.java
@@ -53,14 +53,13 @@ public class VideoController {
     @GetMapping("/my-likes")
     public ApiResponse<Map<String, Object>> getMyLikedVideos(
             @ModelAttribute VideoListRequestDto requestDto,
-            HttpServletRequest request
-    ) {
+            HttpServletRequest request) {
         // 1. Interceptor에서 검증 후 넣어준 userId 꺼내기
         Long userId = (Long) request.getAttribute("userId");
 
         // 2. DTO 설정
-        requestDto.setUserId(userId);       // 영상마다 내가 좋아요 눌렀는지 확인용
-        requestDto.setLikedUserId(userId);  // 이 유저가 좋아요한 영상만 필터링해서 가져옴
+        requestDto.setUserId(userId); // 영상마다 내가 좋아요 눌렀는지 확인용
+        requestDto.setLikedUserId(userId); // 이 유저가 좋아요한 영상만 필터링해서 가져옴
 
         // 3. Service 호출 (기존 목록 조회 로직 재사용)
         List<VideoResponseDto> likedVideos = videoService.getVideoList(requestDto);
@@ -69,6 +68,17 @@ public class VideoController {
         Map<String, Object> data = new HashMap<>();
         data.put("videos", likedVideos);
 
+        return ApiResponse.success(data);
+    }
+
+    // 실시간 급상승 영상 조회
+    @GetMapping("/trending")
+    public ApiResponse<Map<String, Object>> getTrendingVideos(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("userId");
+        List<VideoResponseDto> trendingVideos = videoService.getTrendingVideos(userId);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("videos", trendingVideos);
         return ApiResponse.success(data);
     }
 }

--- a/src/main/java/com/ssook/mvc/dto/user/UserPasswordChangeRequest.java
+++ b/src/main/java/com/ssook/mvc/dto/user/UserPasswordChangeRequest.java
@@ -1,0 +1,20 @@
+package com.ssook.mvc.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserPasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Size(min = 4, message = "비밀번호는 최소 4자 이상이어야 합니다.") // Simple constraint
+    private String newPassword;
+}

--- a/src/main/java/com/ssook/mvc/entity/UserEntity.java
+++ b/src/main/java/com/ssook/mvc/entity/UserEntity.java
@@ -4,25 +4,26 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UserEntity extends BaseEntity { // 상속
-    
-    private Long userId;        // DB: user_id (PK)
-    private String email;       // DB: email
-    private String password;    // DB: password
-    private String nickname;    // DB: nickname
-    private String role;        // DB: role
-    private String intro;       // DB: intro
+
+    private Long userId; // DB: user_id (PK)
+    private String email; // DB: email
+    private String password; // DB: password
+    private String nickname; // DB: nickname
+    private String role; // DB: role
+    private String intro; // DB: intro
     private String profileImage;// DB: profile_image
-    
+
     // createdAt, updatedAt은 부모(BaseEntity)에 있으므로 생략
-    
-    
-	// 회원 정보 수정 편의 메서드
+
+    // 회원 정보 수정 편의 메서드
     public void modify(String nickname, String intro, String profileImage) {
         this.nickname = nickname;
         this.intro = intro;

--- a/src/main/java/com/ssook/mvc/repository/UserMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/UserMapper.java
@@ -14,12 +14,14 @@ public interface UserMapper {
 
     // 닉네임 중복 체크
     boolean existsByNickname(String nickname);
-    
+
     UserEntity findByEmail(String email);
-    
+
     UserEntity findById(Long userId);
-    
-    void updateUser(UserEntity user);
-    
+
+    void updateUser(UserEntity user); // For Profile Info
+
+    void updatePassword(UserEntity user); // For Password Change
+
     void deleteUser(Long userId);
 }

--- a/src/main/java/com/ssook/mvc/repository/VideoMapper.java
+++ b/src/main/java/com/ssook/mvc/repository/VideoMapper.java
@@ -27,4 +27,7 @@ public interface VideoMapper {
 
     // 최애 카테고리 조회
     String selectTopCategory(Long userId);
+
+    // 급상승 영상 조회
+    List<VideoResponseDto> selectTrendingVideos(Long userId);
 }

--- a/src/main/java/com/ssook/mvc/service/UserService.java
+++ b/src/main/java/com/ssook/mvc/service/UserService.java
@@ -20,9 +20,9 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-	
-	private final JwtUtil jwtUtil; // JwtUtil 주입 (RequiredArgsConstructor 덕분에 자동 주입됨)
-	
+
+    private final JwtUtil jwtUtil; // JwtUtil 주입 (RequiredArgsConstructor 덕분에 자동 주입됨)
+
     private final UserMapper userMapper;
 
     // 프론트에서 보여줄 이미지 목록
@@ -54,12 +54,12 @@ public class UserService {
         // 5. DB 저장
         userMapper.saveUser(user);
     }
-    
+
     @Transactional(readOnly = true) // 읽기 전용 모드 (성능 최적화)
     public String login(UserLoginRequest request) {
         // 1. 이메일로 사용자 조회
         UserEntity user = userMapper.findByEmail(request.getEmail());
-        
+
         // 2. 사용자가 없거나, 비밀번호가 틀리면 에러
         if (user == null || !BCrypt.checkpw(request.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
@@ -68,23 +68,23 @@ public class UserService {
         // 3. 인증 성공 시 토큰 생성 후 반환
         return jwtUtil.generateToken(user.getUserId(), user.getEmail());
     }
-    
+
     // 내 정보 조회
     @Transactional(readOnly = true)
     public UserInfoResponse getMyInfo(Long userId) {
         // DB에서 조회
         UserEntity user = userMapper.findById(userId);
-        
+
         // 없으면 에러 (혹시 탈퇴했거나 잘못된 토큰일 경우)
         if (user == null) {
             throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
         }
-        
+
         // Entity -> DTO 변환해서 반환 (비밀번호 제외됨)
         return UserInfoResponse.from(user);
     }
-    
-	// 내 정보 수정
+
+    // 내 정보 수정
     @Transactional
     public UserInfoResponse modifyUser(Long userId, UserModifyRequest request) {
         // 기존 유저 정보 조회
@@ -95,8 +95,8 @@ public class UserService {
 
         // 닉네임 중복 검사 (중요: "닉네임이 바뀌었을 때만" 검사해야 함)
         // 기존 닉네임이랑 다른데(바꿨는데) && DB에 이미 있다면 -> 에러
-        if (!user.getNickname().equals(request.getNickname()) 
-             && userMapper.existsByNickname(request.getNickname())) {
+        if (!user.getNickname().equals(request.getNickname())
+                && userMapper.existsByNickname(request.getNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
@@ -122,7 +122,7 @@ public class UserService {
         // 변경된 최신 정보를 DTO로 변환해서 반환
         return UserInfoResponse.from(user);
     }
-    
+
     // 회원 탈퇴
     @Transactional
     public void deleteUser(Long userId) {
@@ -135,5 +135,26 @@ public class UserService {
         // 삭제 수행
         userMapper.deleteUser(userId);
     }
-    
+
+    // 비밀번호 변경
+    @Transactional
+    public void changePassword(Long userId, com.ssook.mvc.dto.user.UserPasswordChangeRequest request) {
+        // 1. 유저 조회
+        UserEntity user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+
+        // 2. 현재 비밀번호 확인
+        if (!BCrypt.checkpw(request.getCurrentPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 3. 새 비밀번호 암호화 및 설정
+        String newEncodedPassword = BCrypt.hashpw(request.getNewPassword(), BCrypt.gensalt());
+        user.setPassword(newEncodedPassword);
+
+        // 4. DB 업데이트
+        userMapper.updatePassword(user);
+    }
 }

--- a/src/main/java/com/ssook/mvc/service/VideoService.java
+++ b/src/main/java/com/ssook/mvc/service/VideoService.java
@@ -179,4 +179,43 @@ public class VideoService {
                 .watchTime(totalViewCount) // 1분으로 가정
                 .build();
     }
+
+    // 급상승 영상 조회 (Trend)
+    @Transactional(readOnly = true)
+    public List<VideoResponseDto> getTrendingVideos(Long userId) {
+        // 1. 최근 24시간 조회수 높은 영상 3개 조회
+        List<VideoResponseDto> trending = videoMapper.selectTrendingVideos(userId);
+
+        // 2. 만약 3개 미만이라면, 전체 인기순으로 채우기 (중복 제거)
+        if (trending.size() < 3) {
+            VideoListRequestDto fallbackRequest = new VideoListRequestDto();
+            fallbackRequest.setSortedType(2); // 조회수 순
+            fallbackRequest.setPage(1);
+            fallbackRequest.setSize(10); // 넉넉하게 가져와서 필터링 (이미 trending에 있는 것 제외)
+            fallbackRequest.setUserId(userId);
+
+            List<VideoResponseDto> fallback = videoMapper.selectVideoList(fallbackRequest);
+
+            for (VideoResponseDto video : fallback) {
+                if (trending.size() >= 3)
+                    break;
+
+                // 중복 체크
+                boolean exists = false;
+                for (VideoResponseDto t : trending) {
+                    if (t.getVideoId().equals(video.getVideoId())) {
+                        exists = true;
+                        break;
+                    }
+                }
+
+                if (!exists) {
+                    trending.add(video);
+                }
+            }
+        }
+
+        // 그래도 데이터가 없으면... 어쩔 수 없음 (0개 리턴)
+        return trending;
+    }
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -51,6 +51,14 @@
         updated_at = NOW()
     WHERE user_id = #{userId}
 	</update>
+
+    <update id="updatePassword" parameterType="com.ssook.mvc.entity.UserEntity">
+    UPDATE users
+    SET
+        password = #{password},
+        updated_at = NOW()
+    WHERE user_id = #{userId}
+    </update>
 	
 	<delete id="deleteUser" parameterType="long">
     DELETE FROM users WHERE user_id = #{userId}

--- a/src/main/resources/mapper/VideoMapper.xml
+++ b/src/main/resources/mapper/VideoMapper.xml
@@ -46,6 +46,9 @@
             <when test="sortedType == 3">
                 (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) DESC, v.created_at DESC
             </when>
+            <when test="sortedType == 4">
+                RAND()
+            </when>
             <when test="likedUserId != null">
                 r_filter.created_at DESC
             </when>
@@ -104,5 +107,21 @@
         GROUP BY h.category_id
         ORDER BY COUNT(*) DESC
         LIMIT 1
+    </select>
+
+    <!-- 실시간 급상승 영상 조회 (최근 24시간 조회수 기준) -->
+    <select id="selectTrendingVideos" resultType="VideoResponseDto">
+        SELECT v.video_id AS videoId, v.thumbnail_url AS thumbnailUrl, v.view_count AS viewCount,
+               v.title AS title, v.video_url AS videoUrl,
+               (SELECT COUNT(*) FROM comment cm WHERE cm.video_id = v.video_id AND cm.is_deleted = false) AS commentCount,
+               (SELECT COUNT(*) FROM reaction r WHERE r.video_id = v.video_id) AS likeCount,
+               (SELECT COUNT(*) FROM reaction my_r WHERE my_r.video_id = v.video_id AND my_r.user_id = #{userId}) > 0 AS liked,
+               COUNT(h.history_id) as recentViewCount
+        FROM video v
+        JOIN video_view_history h ON v.video_id = h.video_id
+        WHERE h.created_at >= DATE_SUB(NOW(), INTERVAL 1 DAY)
+        GROUP BY v.video_id
+        ORDER BY recentViewCount DESC, v.view_count DESC
+        LIMIT 3
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 개요
- **실시간 인기 쇼츠 조회 기능**과 **회원 프로필 비밀번호 변경 기능**을 구현했습니다.
- 사용자 경험 향상을 위한 데이터 정렬 로직과 보안 강화를 위한 비밀번호 검증 로직을 추가했습니다.

## 👩‍💻 작업 내용
1. **실시간 인기 쇼츠 API 구현 (`GET /video/trending`)**
   - 최근 24시간 내 조회수를 기준으로 상위 3개 영상을 추출하는 쿼리 및 서비스 로직 구현
   - 최근 데이터 부족 시(3개 미만), 전체 인기 영상으로 자동 보정(Fallback)하여 항상 3개가 노출되도록 처리
2. **비밀번호 변경 API 구현 (`PATCH /users/me/password`)**
   - 현재 비밀번호 일치 여부 검증 후 새 비밀번호로 업데이트하는 로직 구현 (`BCrypt` 활용)
   - 비밀번호 변경 전용 DTO ([UserPasswordChangeRequest]) 생성 및 유효성 검사 적용
3. **버그 수정**
   - Entity 및 Service 계층의 컴파일 오류(괄호, Setter 누락 등) 수정

## 🛠️ 기술적 의사결정
- **MyBatis Join 활용**: 별도의 통계 테이블을 매번 갱신하는 대신, `video_view_history` 테이블을 실시간으로 집계하는 방식 채택 (데이터 신선도 보장).
- **별도 엔드포인트 분리**: 비밀번호 변경은 일반적인 회원 정보 수정과 달리 민감한 정보 검증이 필요하므로, `/users/me`(`PATCH`) 대신 `/users/me/password`(`PATCH`)로 명확히 분리하여 보안성과 유지보수성을 높임.

## ✅ 테스트 결과
- [x] **Postman/Swagger**: `/video/trending` 요청 시 순위별 데이터(1~3위) 정상 반환 확인
- [x] **Postman/Swagger**: `/users/me/password` 요청 시 잘못된 현재 비밀번호 입력 400 에러, 정상 입력 시 200 OK 확인

## 🔗 관련 이슈
- #65